### PR TITLE
Fix grammar in chapter 4

### DIFF
--- a/chapter04/docs/04-grammar.md
+++ b/chapter04/docs/04-grammar.md
@@ -59,8 +59,6 @@ unaryExpression
 primaryExpression
     : IDENTIFIER
     | INTEGER_LITERAL
-    | 'true'
-    | 'false'
     | '(' expression ')'
     ;
 


### PR DESCRIPTION
The grammar in chapter 4 lists `'true'` and `'false'` as primary expressions, but the parser does not recognise them. To preserve a simple parser, remove them from the grammar.