### PR TITLE
Fix kill recursion in set_def killing new_def.

### DIFF
--- a/chapter04/src/main/java/com/seaofnodes/simple/node/Node.java
+++ b/chapter04/src/main/java/com/seaofnodes/simple/node/Node.java
@@ -193,14 +193,16 @@ public abstract class Node {
     Node set_def(int idx, Node new_def ) {
         Node old_def = in(idx);
         if( old_def == new_def ) return this; // No change
+        // If new def is not null, add the corresponding def->use edge
+        // This needs to happen before removing the old node's def->use edge as
+        // the new_def might get killed if the old node kills it recursively.
+        if( new_def != null )
+            new_def._outputs.add(this);
         if( old_def != null &&  // If the old def exists, remove a def->use edge
             old_def.delUse(this) ) // If we removed the last use, the old def is now dead
             old_def.kill();     // Kill old def
         // Set the new_def over the old (killed) edge
         _inputs.set(idx,new_def);
-        // If new def is not null, add the corresponding def->use edge
-        if( new_def != null )
-            new_def._outputs.add(this);
         // Return self for easy flow-coding
         return this;
     }

--- a/chapter04/src/test/java/com/seaofnodes/simple/Chapter04Test.java
+++ b/chapter04/src/test/java/com/seaofnodes/simple/Chapter04Test.java
@@ -113,6 +113,13 @@ public class Chapter04Test {
     }
 
     @Test
+    public void testChapter4Bug3() {
+        Parser parser = new Parser("int a=arg*2+1; a=a+-1; return a; #showGraph;", TypeInteger.BOT);
+        ReturnNode ret = parser.parse();
+        assertEquals("return (Proj_3*2);", ret.print());
+    }
+
+    @Test
     public void testVarDecl() {
         Parser parser = new Parser("int a=1; return a;");
         ReturnNode ret = parser.parse();


### PR DESCRIPTION
When using a child of the old node as the new node in a call to `set_def` it can kill the new node since the old node might be the only use. This happens before the new node is assigned and the use is established. To fix this issue create the def->use edge before killing the old node. This ensures that a potential child that is used in the assignment has another use and will not be killed.

The problem shows up in programs like:
```c
int a=arg*2+1; a=a+-1; return a;
```
where `a=a+-1` will be reduced to `a=arg*2` but due to killing the old `arg*2+1` node it also kills `arg*2` before the use is established.