### PR TITLE
Update JDK to 21

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,6 +1,6 @@
 name: Java CI with Maven
 
-on: [push]
+on: [ push, pull_request ]
 
 jobs:
   test:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -9,10 +9,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - name: Set up JDK 20
+      - name: Set up JDK 21
         uses: actions/setup-java@v3
         with:
-          java-version: '20'
+          java-version: '21'
           distribution: 'temurin'
+          cache: 'maven'
       - name: Build with Maven
         run: mvn --batch-mode --update-snapshots verify

--- a/chapter02/src/main/java/com/seaofnodes/simple/node/Node.java
+++ b/chapter02/src/main/java/com/seaofnodes/simple/node/Node.java
@@ -154,6 +154,12 @@ public abstract class Node {
      */
     void set_def(int idx, Node new_def ) {
         Node old_def = in(idx);
+        if( old_def == new_def ) return; // No change
+        // If new def is not null, add the corresponding def->use edge
+        // This needs to happen before removing the old node's def->use edge as
+        // the new_def might get killed if the old node kills it recursively.
+        if( new_def != null )
+            new_def._outputs.add(this);
         if( old_def != null ) { // If the old def exists, remove a use->def edge
             ArrayList<Node> outs = old_def._outputs;
             int lidx = outs.size()-1; // Last index
@@ -168,9 +174,6 @@ public abstract class Node {
         }
         // Set the new_def over the old (killed) edge
         _inputs.set(idx,new_def);
-        // If new def is not null, add the corresponding use->def edge
-        if( new_def != null )
-            new_def._outputs.add(this);
     }
     
   

--- a/chapter03/src/main/java/com/seaofnodes/simple/node/Node.java
+++ b/chapter03/src/main/java/com/seaofnodes/simple/node/Node.java
@@ -155,14 +155,16 @@ public abstract class Node {
     Node set_def(int idx, Node new_def ) {
         Node old_def = in(idx);
         if( old_def == new_def ) return this; // No change
+        // If new def is not null, add the corresponding def->use edge
+        // This needs to happen before removing the old node's def->use edge as
+        // the new_def might get killed if the old node kills it recursively.
+        if( new_def != null )
+            new_def._outputs.add(this);
         if( old_def != null &&  // If the old def exists, remove a def->use edge
             old_def.delUse(this) ) // If we removed the last use, the old def is now dead
                 old_def.kill(); // Kill old def
         // Set the new_def over the old (killed) edge
         _inputs.set(idx,new_def);
-        // If new def is not null, add the corresponding def->use edge
-        if( new_def != null )
-            new_def._outputs.add(this);
         // Return self for easy flow-coding
         return this;
     }

--- a/language/pom.xml
+++ b/language/pom.xml
@@ -15,7 +15,6 @@
 		<maven.compiler.source>21</maven.compiler.source>
 		<antlr4test-maven-plugin.version>1.22</antlr4test-maven-plugin.version>
 		<antlr.version>4.11.1</antlr.version>
-		<antlr4test-maven-plugin.version>1.21</antlr4test-maven-plugin.version>
 		<junit.version>4.13.2</junit.version>
 	</properties>
 	<dependencies>

--- a/language/pom.xml
+++ b/language/pom.xml
@@ -11,8 +11,8 @@
 	<name>SeaOfNodes Demo Simple Language Grammar</name>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<maven.compiler.target>20</maven.compiler.target>
-		<maven.compiler.source>20</maven.compiler.source>
+		<maven.compiler.target>21</maven.compiler.target>
+		<maven.compiler.source>21</maven.compiler.source>
 		<antlr4test-maven-plugin.version>1.22</antlr4test-maven-plugin.version>
 		<antlr.version>4.11.1</antlr.version>
 		<antlr4test-maven-plugin.version>1.21</antlr4test-maven-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -45,16 +45,12 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.1.2</version>
-                <configuration>
-                    <argLine>--enable-preview</argLine>
-                </configuration>
             </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.10.1</version>
                 <configuration>
-                    <release>20</release>
-                    <compilerArgs>--enable-preview</compilerArgs>
+                    <release>21</release>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
Current config (target 20 and with `--enable-preview`) have issue with newer JDK version (e.g. latest LTS, 21, see [error](https://github.com/oraluben/Simple/actions/runs/6717620743/job/18255815060)). Since this project use new Java features, I suggest to switch to JDK 21 and remove the preview option.

PS: I noticed the previous bump was made at the exact day when JDK 21 release :)

Other changes in this pull request:
1. Add cache to CI's maven;
2. fix a pom issue and fix runtime warning for antlr;
3. enable CI for each pull request.