### PR TITLE
Test expecting an excpetion is missing an fail

### DIFF
--- a/chapter05/src/test/java/com/seaofnodes/simple/Chapter05Test.java
+++ b/chapter05/src/test/java/com/seaofnodes/simple/Chapter05Test.java
@@ -301,6 +301,7 @@ return c;
     public void testSelfAssign() {
         try { 
             new Parser("int a=a; return a;").parse();
+            fail();
         } catch( RuntimeException e ) {
             assertEquals("Undefined name 'a'",e.getMessage());
         }


### PR DESCRIPTION
All tests which expect exceptions should end with a `fail` in case no exception was raised.