### PR TITLE
Backport changes from chapter 5 to older chapters

### DIFF
--- a/chapter01/src/main/java/com/seaofnodes/simple/node/ConstantNode.java
+++ b/chapter01/src/main/java/com/seaofnodes/simple/node/ConstantNode.java
@@ -1,5 +1,7 @@
 package com.seaofnodes.simple.node;
 
+import com.seaofnodes.simple.Parser;
+
 /**
  * A Constant node represents a constant value.  At present, the only constants
  * that we allow are integer literals; therefore Constants contain an integer
@@ -16,8 +18,8 @@ public class ConstantNode extends Node {
 
     public final long _value;
 
-    public ConstantNode(long value, StartNode startNode) {
-        super(startNode);
+    public ConstantNode(long value) {
+        super(Parser.START);
         _value = value;
     }
 }

--- a/chapter01/src/main/java/com/seaofnodes/simple/node/Control.java
+++ b/chapter01/src/main/java/com/seaofnodes/simple/node/Control.java
@@ -1,9 +1,0 @@
-package com.seaofnodes.simple.node;
-
-
-/**
- * Control interface is a marker interface to be implemented
- * by Control nodes.
- */
-public interface Control {
-}

--- a/chapter01/src/main/java/com/seaofnodes/simple/node/Node.java
+++ b/chapter01/src/main/java/com/seaofnodes/simple/node/Node.java
@@ -1,7 +1,6 @@
 package com.seaofnodes.simple.node;
 
-import java.util.ArrayList;
-import java.util.Collections;
+import java.util.*;
 
 /**
  * All Nodes in the Sea of Nodes IR inherit from the Node class.
@@ -22,8 +21,7 @@ public abstract class Node {
      * <p>
      * Generally fixed length, ordered, nulls allowed, no unused trailing space.
      * Ordering is required because e.g. "a/b" is different from "b/a".
-     * The first input (offset 0) is often a Control node.
-     * @see Control
+     * The first input (offset 0) is often a {@link #isCFG} node.
      */
     public final ArrayList<Node> _inputs;
 
@@ -45,17 +43,16 @@ public abstract class Node {
      * */
     private static int UNIQUE_ID = 1;
 
-    protected Node(Node ...inputs) {
+    protected Node(Node... inputs) {
         _nid = UNIQUE_ID++; // allocate unique dense ID
         _inputs = new ArrayList<>();
         Collections.addAll(_inputs,inputs);
         _outputs = new ArrayList<>();
-        for( Node n : _inputs ) {
+        for( Node n : _inputs )
             if( n != null )
                 n._outputs.add( this );
-      }
     }
-
+    
     /**
      * Gets the ith input node
      * @param i Offset of the input node
@@ -65,23 +62,16 @@ public abstract class Node {
 
     public int nIns() { return _inputs.size(); }
 
-    /**
-     * Gets the ith output node
-     * @param i Offset of the output node
-     * @return Output node (not null)
-     */
-    public Node out(int i) { return _outputs.get(i); }
-
     public int nOuts() { return _outputs.size(); }
+
+    public boolean isUnused() { return nOuts() == 0; }
+
+    public boolean isCFG() { return false; }
+  
 
     /**
      * Used to allow repeating tests in the same JVM.  This just resets the
      * Node unique id generator, and is done as part of making a new Parser.
      */
-    public static void reset() {
-        UNIQUE_ID = 1;
-    }
-    /*
-     * hashCode and equals implementation to be added in later chapter.
-     */
+    public static void reset() { UNIQUE_ID = 1; }
 }

--- a/chapter01/src/main/java/com/seaofnodes/simple/node/ReturnNode.java
+++ b/chapter01/src/main/java/com/seaofnodes/simple/node/ReturnNode.java
@@ -9,17 +9,15 @@ package com.seaofnodes.simple.node;
  * <p>
  * The Return's output is the value from the data node.
  */
-public class ReturnNode extends Node implements Control {
+public class ReturnNode extends Node {
 
     public ReturnNode(Node ctrl, Node data) {
         super(ctrl, data);
     }
 
-    public Node ctrl() {
-        return in(0);
-    }
+    public Node ctrl() { return in(0); }
+    public Node expr() { return in(1); }
 
-    public Node expr() {
-        return in(1);
-    }
+    @Override public boolean isCFG() { return true; }
+  
 }

--- a/chapter01/src/main/java/com/seaofnodes/simple/node/StartNode.java
+++ b/chapter01/src/main/java/com/seaofnodes/simple/node/StartNode.java
@@ -5,9 +5,12 @@ package com.seaofnodes.simple.node;
  * yet accept parameters.  When we add parameters the value of Start will be a tuple, and will require Projections to extract the values.
  * We discuss this in detail in Chapter 9: Functions and Calls.
  */
-public class StartNode extends Node implements Control {
+public class StartNode extends Node {
 
     public StartNode(/*arguments go here*/) {
         super();
     }
+
+    @Override public boolean isCFG() { return true; }
+
 }

--- a/chapter01/src/test/java/com/seaofnodes/simple/Chapter01Test.java
+++ b/chapter01/src/test/java/com/seaofnodes/simple/Chapter01Test.java
@@ -1,15 +1,11 @@
 package com.seaofnodes.simple;
 
-import com.seaofnodes.simple.node.ConstantNode;
-import com.seaofnodes.simple.node.Node;
-import com.seaofnodes.simple.node.ReturnNode;
-import com.seaofnodes.simple.node.StartNode;
+import com.seaofnodes.simple.node.*;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
 public class Chapter01Test {
 
@@ -21,11 +17,11 @@ public class Chapter01Test {
         Parser parser = new Parser("return 1;");
         ReturnNode ret = parser.parse();
         StartNode start = Parser.START;
-
+        
         assertEquals(start, ret.ctrl());
         Node expr = ret.expr();
-        if (expr instanceof ConstantNode con) {
-            assertEquals(start, con.in(0));
+        if( expr instanceof ConstantNode con ) {
+            assertEquals(start,con.in(0));
             assertEquals(1, con._value);
         } else {
             fail();
@@ -44,16 +40,22 @@ public class Chapter01Test {
 
     @Test
     public void testBad1() {
-        exceptionRule.expect(RuntimeException.class);
-        exceptionRule.expectMessage("Syntax error, expected return: ret");
-        new Parser("ret").parse();
+        try { 
+            new Parser("ret").parse();
+            fail();
+        } catch( RuntimeException e ) {
+            assertEquals("Syntax error, expected return: ret",e.getMessage());
+        }
     }
 
     @Test
     public void testBad2() {
-        exceptionRule.expect(RuntimeException.class);
-        exceptionRule.expectMessage("Syntax error: integer values cannot start with '0'");
-        new Parser("return 0123;").parse();
+        try { 
+            new Parser("return 0123;").parse();
+            fail();
+        } catch( RuntimeException e ) {
+            assertEquals("Syntax error: integer values cannot start with '0'",e.getMessage());
+        }
     }
 
     @Test
@@ -65,9 +67,12 @@ public class Chapter01Test {
 
     @Test
     public void testBad4() {
-        exceptionRule.expect(RuntimeException.class);
-        exceptionRule.expectMessage("Syntax error, expected ;:");
-        new Parser("return 100").parse();
+        try { 
+            new Parser("return 100").parse();
+            fail();
+        } catch( RuntimeException e ) {
+            assertEquals("Syntax error, expected ;: ",e.getMessage());
+        }
     }
 
     // Negative numbers require unary operator support that is not in scope

--- a/chapter02/src/main/java/com/seaofnodes/simple/GraphVisualizer.java
+++ b/chapter02/src/main/java/com/seaofnodes/simple/GraphVisualizer.java
@@ -1,9 +1,6 @@
 package com.seaofnodes.simple;
 
-import com.seaofnodes.simple.node.ConstantNode;
-import com.seaofnodes.simple.node.Control;
-import com.seaofnodes.simple.node.Node;
-import com.seaofnodes.simple.node.StartNode;
+import com.seaofnodes.simple.node.*;
 
 import java.util.*;
 
@@ -21,7 +18,10 @@ public class GraphVisualizer {
         Collection<Node> all = findAll(parser);
         StringBuilder sb = new StringBuilder();
         sb.append("digraph chapter02 {\n");
-
+        sb.append("/*\n");
+        sb.append(parser.src());
+        sb.append("\n*/\n");
+        
         // To keep the Scopes below the graph and pointing up into the graph we
         // need to group the Nodes in a subgraph cluster, and the scopes into a
         // different subgraph cluster.  THEN we can draw edges between the
@@ -29,12 +29,19 @@ public class GraphVisualizer {
         // still making the subgraphs DOT gets confused.
         sb.append("\trankdir=BT;\n"); // Force Nodes before Scopes
 
+        // Preserve node input order
+        sb.append("\tordering=\"in\";\n");
+
+        // Merge multiple edges hitting the same node.  Makes common shared
+        // nodes much prettier to look at.
+        sb.append("\tconcentrate=\"true\";\n");
+        
         // Just the Nodes first, in a cluster no edges
         nodes(sb, all);
 
         // Walk the Node edges
         nodeEdges(sb, all);
-
+        
         sb.append("}\n");
         return sb.toString();
     }
@@ -43,13 +50,14 @@ public class GraphVisualizer {
     private void nodes(StringBuilder sb, Collection<Node> all) {
         // Just the Nodes first, in a cluster no edges
         sb.append("\tsubgraph cluster_Nodes {\n"); // Magic "cluster_" in the subgraph name
-        for (Node n : all) {
+        for( Node n : all ) {
             sb.append("\t\t").append(n.uniqueName()).append(" [ ");
+            String lab = n.glabel();
             // control nodes have box shape
             // other nodes are ellipses, i.e. default shape
-            if (n instanceof Control)
+            if( n.isCFG() )
                 sb.append("shape=box style=filled fillcolor=yellow ");
-            sb.append("label=\"").append(n.label()).append("\" ");
+            sb.append("label=\"").append(lab).append("\" ");
             sb.append("];\n");
         }
         sb.append("\t}\n");     // End Node cluster
@@ -58,25 +66,32 @@ public class GraphVisualizer {
 
     // Walk the node edges
     private void nodeEdges(StringBuilder sb, Collection<Node> all) {
-        for( Node n : all )
-            for( Node out : n._inputs )
-                if( out != null ) {
-                    sb.append('\t').append(n.uniqueName()).append(" -> ").append(out.uniqueName());
-                    // Control edges are colored red
-                    if( n instanceof ConstantNode && out instanceof StartNode )
-                sb.append(" [style=dotted]");
-                    else if( n instanceof Control && out instanceof Control )
-                      sb.append(" [color=red]");
-            sb.append(";\n");
+        // All them edge labels
+        sb.append("\tedge [ fontname=Helvetica, fontsize=8 ];\n");
+        for( Node n : all ) {
+            // Do not display the Constant->Start edge;
+            if( n instanceof ConstantNode )
+                continue;
+            int i=0;
+            for( Node def : n._inputs ) {
+                if( def != null ) {
+                    // Most edges land here use->def
+                    sb.append('\t').append(n.uniqueName()).append(" -> ");
+                    sb.append(def.uniqueName());
+                    // Number edges, so we can see how they track
+                    sb.append("[taillabel=").append(i);
+                    // control edges are colored red
+                    if( def.isCFG() )
+                        sb.append("; color=red");
+                    sb.append("];\n");
+                }
+                i++;
+            }
         }
     }
-
+    
     /**
-     * Walks the whole graph, starting from Start.
-     * Since Start is the input to all constants - we look at the outputs for
-     * Start, but for then subsequently we look at the inputs of each node.
-     * During graph construction not all nodes are reachable this way, so we
-     * also scan the symbol tables.
+     * Finds all nodes in the graph.
      */
     private Collection<Node> findAll(Parser parser) {
         final StartNode start = Parser.START;
@@ -91,9 +106,12 @@ public class GraphVisualizer {
      */
     private void walk(HashMap<Integer, Node> all, Node n) {
         if (all.get(n._nid) != null) return; // Been there, done that
-            all.put(n._nid, n);
-            for (Node c : n._inputs)
-                if (c != null)
-                    walk(all, c);
+        all.put(n._nid, n);
+        for (Node c : n._inputs)
+            if (c != null)
+                walk(all, c);
+        for (Node c : n._outputs)
+            if (c != null)
+                walk(all, c);
     }
 }

--- a/chapter02/src/main/java/com/seaofnodes/simple/node/AddNode.java
+++ b/chapter02/src/main/java/com/seaofnodes/simple/node/AddNode.java
@@ -3,17 +3,16 @@ package com.seaofnodes.simple.node;
 import com.seaofnodes.simple.type.*;
 
 public class AddNode extends Node {
-    public AddNode(Node lhs, Node rhs) {
-        super(null, lhs, rhs);
-    }
+    public AddNode(Node lhs, Node rhs) { super(null, lhs, rhs); }
+
+    @Override public String label() { return "Add"; }
+    
+    @Override public String glabel() { return "+"; }
 
     @Override
-    public String label() { return "Add"; }
-
-    @Override
-    StringBuilder _print(StringBuilder sb) {
-        in(1)._print(sb.append("("));
-        in(2)._print(sb.append("+"));
+    StringBuilder _print1(StringBuilder sb) {
+        in(1)._print0(sb.append("("));
+        in(2)._print0(sb.append("+"));
         return sb.append(")");
     }
   
@@ -21,8 +20,9 @@ public class AddNode extends Node {
     @Override
     public Type compute() {
         if( in(1)._type instanceof TypeInteger i0 &&
-            in(2)._type instanceof TypeInteger i1 )
-            return new TypeInteger(i0._con + i1._con);
+            in(2)._type instanceof TypeInteger i1 ) {
+            return TypeInteger.constant(i0.value()+i1.value());
+        }
         return TypeBot.BOTTOM;
     }
 

--- a/chapter02/src/main/java/com/seaofnodes/simple/node/ConstantNode.java
+++ b/chapter02/src/main/java/com/seaofnodes/simple/node/ConstantNode.java
@@ -16,22 +16,25 @@ import com.seaofnodes.simple.type.Type;
  * The Constant's value is the value stored in it.
  */
 public class ConstantNode extends Node {
-
+    Type _con;
     public ConstantNode( Type type ) {
         super(Parser.START);
-        _type = type;
+        _con = type;
     }
     
     @Override
-    public String label() { return "Con" + _type; }
+    public String label() { return "#"+_con; }
+  
+    @Override
+    public String uniqueName() { return "Con_" + _nid; }
 
     @Override
-    StringBuilder _print(StringBuilder sb) {
-        return _type._print(sb);
+    StringBuilder _print1(StringBuilder sb) {
+        return _con._print(sb);
     }
     
     @Override
-    public Type compute() { return _type; }
+    public Type compute() { return _con; }
 
     @Override
     public Node idealize() { return null; }

--- a/chapter02/src/main/java/com/seaofnodes/simple/node/Control.java
+++ b/chapter02/src/main/java/com/seaofnodes/simple/node/Control.java
@@ -1,9 +1,0 @@
-package com.seaofnodes.simple.node;
-
-
-/**
- * Control interface is a marker interface to be implemented
- * by Control nodes.
- */
-public interface Control {
-}

--- a/chapter02/src/main/java/com/seaofnodes/simple/node/DivNode.java
+++ b/chapter02/src/main/java/com/seaofnodes/simple/node/DivNode.java
@@ -5,17 +5,16 @@ import com.seaofnodes.simple.type.TypeBot;
 import com.seaofnodes.simple.type.TypeInteger;
 
 public class DivNode extends Node {
-    public DivNode(Node lhs, Node rhs) {
-        super(null, lhs, rhs);
-    }
+    public DivNode(Node lhs, Node rhs) { super(null, lhs, rhs); }
+
+    @Override public String label() { return "Div"; }
+
+    @Override public String glabel() { return "//"; }
 
     @Override
-    public String label() { return "Div"; }
-  
-    @Override
-    StringBuilder _print(StringBuilder sb) {
-        in(1)._print(sb.append("("));
-        in(2)._print(sb.append("/"));
+    StringBuilder _print1(StringBuilder sb) {
+        in(1)._print0(sb.append("("));
+        in(2)._print0(sb.append("/"));
         return sb.append(")");
     }
   
@@ -23,11 +22,9 @@ public class DivNode extends Node {
     public Type compute() {
         if (in(1)._type instanceof TypeInteger i0 &&
             in(2)._type instanceof TypeInteger i1) {
-            if (i0.isConstant() && i1.isConstant())
-                return i1._con == 0
-                    ? TypeInteger.ZERO
-                    : new TypeInteger(i0._con/i1._con);
-            return new TypeInteger(i0._con / i1._con);
+            return i1.value() == 0
+                ? TypeInteger.ZERO
+                : TypeInteger.constant(i0.value()/i1.value());
         }
         return TypeBot.BOTTOM;
     }

--- a/chapter02/src/main/java/com/seaofnodes/simple/node/MinusNode.java
+++ b/chapter02/src/main/java/com/seaofnodes/simple/node/MinusNode.java
@@ -5,23 +5,22 @@ import com.seaofnodes.simple.type.TypeBot;
 import com.seaofnodes.simple.type.TypeInteger;
 
 public class MinusNode extends Node {
-    public MinusNode(Node in) {
-        super(null, in);
-    }
+    public MinusNode(Node in) { super(null, in); }
 
-    @Override
-    public String label() { return "Minus"; }
+    @Override public String label() { return "Minus"; }
+  
+    @Override public String glabel() { return "-"; }
   
     @Override
-    StringBuilder _print(StringBuilder sb) {
-        in(1)._print(sb.append("(-"));
+    StringBuilder _print1(StringBuilder sb) {
+        in(1)._print0(sb.append("(-"));
         return sb.append(")");
     }
   
     @Override
     public Type compute() {
         if (in(1)._type instanceof TypeInteger i0)
-            return new TypeInteger(-i0._con);
+            return TypeInteger.constant(-i0.value());
         return TypeBot.BOTTOM;
     }
 

--- a/chapter02/src/main/java/com/seaofnodes/simple/node/MulNode.java
+++ b/chapter02/src/main/java/com/seaofnodes/simple/node/MulNode.java
@@ -5,25 +5,25 @@ import com.seaofnodes.simple.type.TypeBot;
 import com.seaofnodes.simple.type.TypeInteger;
 
 public class MulNode extends Node {
-    public MulNode(Node lhs, Node rhs) {
-        super(null, lhs, rhs);
-    }
+    public MulNode(Node lhs, Node rhs) { super(null, lhs, rhs); }
+
+    @Override public String label() { return "Mul"; }
   
+    @Override public String glabel() { return "*"; }
+
     @Override
-    public String label() { return "Mul"; }
-  
-    @Override
-    StringBuilder _print(StringBuilder sb) {
-        in(1)._print(sb.append("("));
-        in(2)._print(sb.append("*"));
+    StringBuilder _print1(StringBuilder sb) {
+        in(1)._print0(sb.append("("));
+        in(2)._print0(sb.append("*"));
         return sb.append(")");
     }
-  
+
     @Override
     public Type compute() {
         if (in(1)._type instanceof TypeInteger i0 &&
-                in(2)._type instanceof TypeInteger i1)
-            return new TypeInteger(i0._con * i1._con);
+            in(2)._type instanceof TypeInteger i1) {
+            return TypeInteger.constant(i0.value()*i1.value());
+        }
         return TypeBot.BOTTOM;
     }
 

--- a/chapter02/src/main/java/com/seaofnodes/simple/node/ReturnNode.java
+++ b/chapter02/src/main/java/com/seaofnodes/simple/node/ReturnNode.java
@@ -1,6 +1,6 @@
 package com.seaofnodes.simple.node;
 
-import com.seaofnodes.simple.type.TypeBot;
+import com.seaofnodes.simple.type.*;
 
 /**
  * The Return node has two inputs.  The first input is a control node and the
@@ -11,7 +11,7 @@ import com.seaofnodes.simple.type.TypeBot;
  * <p>
  * The Return's output is the value from the data node.
  */
-public class ReturnNode extends Node implements Control {
+public class ReturnNode extends Node {
 
     public ReturnNode(Node ctrl, Node data) {
         super(ctrl, data);
@@ -24,10 +24,11 @@ public class ReturnNode extends Node implements Control {
     public String label() { return "Return"; }
 
     @Override
-    StringBuilder _print(StringBuilder sb) {
-        return expr()._print(sb.append("return ")).append(";");
+    StringBuilder _print1(StringBuilder sb) {
+        return expr()._print0(sb.append("return ")).append(";");
     }
 
+    @Override public boolean isCFG() { return true; }
   
     @Override
     public TypeBot compute() {

--- a/chapter02/src/main/java/com/seaofnodes/simple/node/StartNode.java
+++ b/chapter02/src/main/java/com/seaofnodes/simple/node/StartNode.java
@@ -3,11 +3,13 @@ package com.seaofnodes.simple.node;
 import com.seaofnodes.simple.type.TypeBot;
 
 /**
- * The Start node represents the start of the function.  For now, we do not have any inputs to Start because our function does not
- * yet accept parameters.  When we add parameters the value of Start will be a tuple, and will require Projections to extract the values.
- * We discuss this in detail in Chapter 9: Functions and Calls.
+ * The Start node represents the start of the function.  For now, we do not
+ * have any inputs to Start because our function does not yet accept
+ * parameters.  When we add parameters the value of Start will be a tuple, and
+ * will require Projections to extract the values.  We discuss this in detail
+ * in Chapter 9: Functions and Calls.
  */
-public class StartNode extends Node implements Control {
+public class StartNode extends Node {
 
     public StartNode(/*arguments go here*/) {
         super();
@@ -17,10 +19,12 @@ public class StartNode extends Node implements Control {
     public String label() { return "Start"; }
 
     @Override
-    StringBuilder _print(StringBuilder sb) {
+    StringBuilder _print1(StringBuilder sb) {
       return sb.append(label());
     }
-  
+
+    @Override public boolean isCFG() { return true; }
+
     @Override
     public TypeBot compute() {
         return TypeBot.BOTTOM;

--- a/chapter02/src/main/java/com/seaofnodes/simple/node/SubNode.java
+++ b/chapter02/src/main/java/com/seaofnodes/simple/node/SubNode.java
@@ -5,25 +5,25 @@ import com.seaofnodes.simple.type.TypeBot;
 import com.seaofnodes.simple.type.TypeInteger;
 
 public class SubNode extends Node {
-    public SubNode(Node lhs, Node rhs) {
-        super(null, lhs, rhs);
-    }
+    public SubNode(Node lhs, Node rhs) { super(null, lhs, rhs); }
+
+    @Override public String label() { return "Sub"; }
+
+    @Override public String glabel() { return "-"; }
 
     @Override
-    public String label() { return "Sub"; }
-
-    @Override
-    StringBuilder _print(StringBuilder sb) {
-        in(1)._print(sb.append("("));
-        in(2)._print(sb.append("-"));
+    StringBuilder _print1(StringBuilder sb) {
+        in(1)._print0(sb.append("("));
+        in(2)._print0(sb.append("-"));
         return sb.append(")");
     }
   
     @Override
     public Type compute() {
         if (in(1)._type instanceof TypeInteger i0 &&
-                in(2)._type instanceof TypeInteger i1)
-            return new TypeInteger(i0._con - i1._con);
+            in(2)._type instanceof TypeInteger i1) {
+            return TypeInteger.constant(i0.value()-i1.value());
+        }
         return TypeBot.BOTTOM;
     }
 

--- a/chapter02/src/main/java/com/seaofnodes/simple/type/TypeBot.java
+++ b/chapter02/src/main/java/com/seaofnodes/simple/type/TypeBot.java
@@ -8,7 +8,7 @@ public class TypeBot extends Type {
   
     @Override
     public String toString() { return "Bottom"; }
-  
-    @Override 
+
+    @Override
     public StringBuilder _print(StringBuilder sb) { return sb.append(toString()); }
 }

--- a/chapter02/src/main/java/com/seaofnodes/simple/type/TypeInteger.java
+++ b/chapter02/src/main/java/com/seaofnodes/simple/type/TypeInteger.java
@@ -14,6 +14,8 @@ public class TypeInteger extends Type {
 
     public TypeInteger(long con) { _con = con; }
 
+    public static TypeInteger constant(long con) { return new TypeInteger(con); }
+
     @Override
     public String toString() {
       return _print(new StringBuilder()).toString();
@@ -25,7 +27,7 @@ public class TypeInteger extends Type {
     @Override
     public boolean isConstant() { return true; }
 
-    public long getConstant() { return _con; }
+    public long value() { return _con; }
 
     @Override
     public boolean equals( Object o ) {

--- a/chapter02/src/test/java/com/seaofnodes/simple/Chapter02Test.java
+++ b/chapter02/src/test/java/com/seaofnodes/simple/Chapter02Test.java
@@ -1,16 +1,12 @@
 package com.seaofnodes.simple;
 
-import com.seaofnodes.simple.node.ConstantNode;
-import com.seaofnodes.simple.node.Node;
-import com.seaofnodes.simple.node.ReturnNode;
-import com.seaofnodes.simple.node.StartNode;
+import com.seaofnodes.simple.node.*;
 import com.seaofnodes.simple.type.TypeInteger;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
 public class Chapter02Test {
 
@@ -76,15 +72,13 @@ public class Chapter02Test {
     public void testSimpleProgram() {
         Parser parser = new Parser("return 1;");
         ReturnNode ret = parser.parse();
-        GraphVisualizer gv = new GraphVisualizer();
-        System.out.println(gv.generateDotOutput(parser));
         StartNode start = Parser.START;
         
         assertEquals(start, ret.ctrl());
         Node expr = ret.expr();
         if( expr instanceof ConstantNode con ) {
             assertEquals(start,con.in(0));
-            assertEquals(new TypeInteger(1), con._type);
+            assertEquals(TypeInteger.constant(1), con._type);
         } else {
             fail();
         }
@@ -97,21 +91,27 @@ public class Chapter02Test {
         StartNode start = Parser.START;
         for( Node use : start._outputs )
             if( use instanceof ConstantNode con )
-                assertEquals(new TypeInteger(0),con._type);
+                assertEquals(TypeInteger.constant(0),con._type);
     }
 
     @Test
     public void testBad1() {
-        exceptionRule.expect(RuntimeException.class);
-        exceptionRule.expectMessage("Syntax error, expected return: ret");
-        new Parser("ret").parse();
+        try { 
+            new Parser("ret").parse();
+            fail();
+        } catch( RuntimeException e ) {
+            assertEquals("Syntax error, expected return: ret",e.getMessage());
+        }
     }
 
     @Test
     public void testBad2() {
-        exceptionRule.expect(RuntimeException.class);
-        exceptionRule.expectMessage("Syntax error: integer values cannot start with '0'");
-        new Parser("return 0123;").parse();
+        try { 
+            new Parser("return 0123;").parse();
+            fail();
+        } catch( RuntimeException e ) {
+            assertEquals("Syntax error: integer values cannot start with '0'",e.getMessage());
+        }
     }
 
     @Test
@@ -122,9 +122,12 @@ public class Chapter02Test {
 
     @Test
     public void testBad4() {
-        exceptionRule.expect(RuntimeException.class);
-        exceptionRule.expectMessage("Syntax error, expected ;:");
-        new Parser("return 100").parse();
+        try { 
+            new Parser("return 100").parse();
+            fail();
+        } catch( RuntimeException e ) {
+            assertEquals("Syntax error, expected ;: ",e.getMessage());
+        }
     }
 
     @Test

--- a/chapter03/src/main/java/com/seaofnodes/simple/GraphVisualizer.java
+++ b/chapter03/src/main/java/com/seaofnodes/simple/GraphVisualizer.java
@@ -18,6 +18,9 @@ public class GraphVisualizer {
         Collection<Node> all = findAll(parser);
         StringBuilder sb = new StringBuilder();
         sb.append("digraph chapter03 {\n");
+        sb.append("/*\n");
+        sb.append(parser.src());
+        sb.append("\n*/\n");
         
         // To keep the Scopes below the graph and pointing up into the graph we
         // need to group the Nodes in a subgraph cluster, and the scopes into a
@@ -25,6 +28,13 @@ public class GraphVisualizer {
         // scopes and nodes.  If we try to cross subgraph cluster borders while
         // still making the subgraphs DOT gets confused.
         sb.append("\trankdir=BT;\n"); // Force Nodes before Scopes
+
+        // Preserve node input order
+        sb.append("\tordering=\"in\";\n");
+
+        // Merge multiple edges hitting the same node.  Makes common shared
+        // nodes much prettier to look at.
+        sb.append("\tconcentrate=\"true\";\n");
         
         // Just the Nodes first, in a cluster no edges
         nodes(sb, all);
@@ -47,12 +57,15 @@ public class GraphVisualizer {
         // Just the Nodes first, in a cluster no edges
         sb.append("\tsubgraph cluster_Nodes {\n"); // Magic "cluster_" in the subgraph name
         for( Node n : all ) {
+            if( n instanceof ScopeNode )
+                continue; // Do not emit, rolled into Scope cluster already
             sb.append("\t\t").append(n.uniqueName()).append(" [ ");
+            String lab = n.glabel();
             // control nodes have box shape
             // other nodes are ellipses, i.e. default shape
-            if( n instanceof Control )
+            if( n.isCFG() )
                 sb.append("shape=box style=filled fillcolor=yellow ");
-            sb.append("label=\"").append(n.label()).append("\" ");
+            sb.append("label=\"").append(lab).append("\" ");
             sb.append("];\n");
         }
         sb.append("\t}\n");     // End Node cluster
@@ -62,12 +75,12 @@ public class GraphVisualizer {
         sb.append("\tnode [shape=plaintext];\n");
         int level=0;
         for( HashMap<String,Integer> scope : scopenode._scopes ) {
-            sb.append("\tsubgraph cluster_").append(level).append(" {\n"); // Magic "cluster_" in the subgraph name
-            String scopeName = makeScopeName(level);
+            String scopeName = makeScopeName(scopenode, level);
+            sb.append("\tsubgraph cluster_").append(scopeName).append(" {\n"); // Magic "cluster_" in the subgraph name
             sb.append("\t\t").append(scopeName).append(" [label=<\n");
             sb.append("\t\t\t<TABLE BORDER=\"0\" CELLBORDER=\"1\" CELLSPACING=\"0\">\n");
             // Add the scope level
-            sb.append("\t\t\t<TR><TD BGCOLOR=\"aqua\">").append(level).append("</TD>");
+            sb.append("\t\t\t<TR><TD BGCOLOR=\"cyan\">").append(level).append("</TD>");
             for( String name : scope.keySet() )
                 sb.append("<TD PORT=\"").append(makePortName(scopeName, name)).append("\">").append(name).append("</TD>");
             sb.append("</TR>\n");
@@ -79,23 +92,35 @@ public class GraphVisualizer {
         // We close them all at once here.
         sb.append( "\t}\n".repeat( level ) ); // End all Scope clusters
     }
-    
-    private String makeScopeName(int level) { return "scope" + level; }
+
+    private String makeScopeName(ScopeNode sn, int level) { return sn.uniqueName() + "_" + level; }
     private String makePortName(String scopeName, String varName) { return scopeName + "_" + varName; }
 
     // Walk the node edges
     private void nodeEdges(StringBuilder sb, Collection<Node> all) {
-        for( Node n : all )
-            for( Node out : n._inputs )
-                if( out != null ) {
-                    sb.append('\t').append(n.uniqueName()).append(" -> ").append(out.uniqueName());
-                    // Control edges are colored red
-                    if( n instanceof ConstantNode && out instanceof StartNode )
-                      sb.append(" [style=dotted]");
-                    else if( n instanceof Control && out instanceof Control )
-                      sb.append(" [color=red]");
-                    sb.append(";\n");
+        // All them edge labels
+        sb.append("\tedge [ fontname=Helvetica, fontsize=8 ];\n");
+        for( Node n : all ) {
+            // Do not display the Constant->Start edge;
+            // ScopeNodes are done separately
+            if( n instanceof ConstantNode || n instanceof ScopeNode )
+                continue;
+            int i=0;
+            for( Node def : n._inputs ) {
+                if( def != null ) {
+                    // Most edges land here use->def
+                    sb.append('\t').append(n.uniqueName()).append(" -> ");
+                    sb.append(def.uniqueName());
+                    // Number edges, so we can see how they track
+                    sb.append("[taillabel=").append(i);
+                    // control edges are colored red
+                    if( def.isCFG() )
+                        sb.append("; color=red");
+                    sb.append("];\n");
                 }
+                i++;
+            }
+        }
     }
     
     // Walk the scope edges
@@ -103,19 +128,23 @@ public class GraphVisualizer {
         sb.append("\tedge [style=dashed color=cornflowerblue];\n");
         int level=0;
         for( HashMap<String,Integer> scope : scopenode._scopes ) {
-            String scopeName = makeScopeName(level);
-            for( String name : scope.keySet() )
-                sb.append("\t").append(scopeName).append(":").append(makePortName(scopeName, name)).append(" -> ").append(scopenode.in(scope.get(name)).uniqueName()).append(";\n");
+            String scopeName = makeScopeName(scopenode, level);
+            for( String name : scope.keySet() ) {
+                Node def = scopenode.in(scope.get(name));
+                if( def==null ) continue;
+                sb.append("\t")
+                  .append(scopeName).append(":")
+                  .append('"').append(makePortName(scopeName, name)).append('"') // wrap port name with quotes because $ctrl is not valid unquoted
+                  .append(" -> ");
+                sb.append(def.uniqueName());
+                sb.append(";\n");
+            }
             level++;
         }
     }
     
     /**
-     * Walks the whole graph, starting from Start.
-     * Since Start is the input to all constants - we look at the outputs for
-     * Start, but for then subsequently we look at the inputs of each node.
-     * During graph construction not all nodes are reachable this way, so we
-     * also scan the symbol tables.
+     * Finds all nodes in the graph.
      */
     private Collection<Node> findAll(Parser parser) {
         final StartNode start = Parser.START;
@@ -133,9 +162,13 @@ public class GraphVisualizer {
      * Walk a subgraph and populate distinct nodes in the all list.
      */
     private void walk(HashMap<Integer, Node> all, Node n) {
+        if(n == null ) return;
         if (all.get(n._nid) != null) return; // Been there, done that
         all.put(n._nid, n);
         for (Node c : n._inputs)
+            if (c != null)
+                walk(all, c);
+        for (Node c : n._outputs)
             if (c != null)
                 walk(all, c);
     }

--- a/chapter03/src/main/java/com/seaofnodes/simple/Parser.java
+++ b/chapter03/src/main/java/com/seaofnodes/simple/Parser.java
@@ -23,6 +23,7 @@ public class Parser {
      */
     public static StartNode START;
 
+    // The Lexer.  Thin wrapper over a byte[] buffer with a cursor.
     private final Lexer _lexer;
 
     /**
@@ -31,17 +32,33 @@ public class Parser {
      */
     public ScopeNode _scope;
 
+    /**
+     * List of keywords disallowed as identifiers
+     */
+    private final HashSet<String> KEYWORDS = new HashSet<>(){{
+            add("int");
+            add("return");
+        }};
+
+
     public Parser(String source) {
         _lexer = new Lexer(source);
-        _scope = new ScopeNode();
         Node.reset();
+        _scope = new ScopeNode();
         START = new StartNode();
     }
 
-    public ReturnNode parse() {
-        return (ReturnNode) parseBlock(false);
-    }
+    String src() { return new String( _lexer._input ); }
 
+    public ReturnNode parse() { return parse(false); }
+    public ReturnNode parse(boolean show) {
+        try {
+            return (ReturnNode) parseBlock();
+        }
+        finally {
+            if( show ) showGraph();
+        }
+    }
 
     /**
      * Parses a block
@@ -49,23 +66,17 @@ public class Parser {
      * <pre>
      *     '{' statements '}'
      * </pre>
+     * Does not parse the opening or closing '{}'
+     * @return a {@link Node} or {@code null}
      */
-    private Node parseBlock(boolean requireClosingBracket) {
+    private Node parseBlock() {
         // Enter a new scope
         _scope.push();
         Node n = null;
-        do {
-            if (match("}")) {
-                if (requireClosingBracket) break;
-                else throw error("unexpected '}' token");
-            } else if (_lexer.isEOF()) {
-                if (requireClosingBracket) require("}");
-                else break;
-            }
-
+        while (!peek('}') && !_lexer.isEOF()) {
             Node n0 = parseStatement();
             if (n0 != null) n = n0; // Allow null returns from eg showGraph
-        } while (true);
+        };
         // Exit scope
         _scope.pop();
         return n;
@@ -77,32 +88,34 @@ public class Parser {
      * <pre>
      *     returnStatement | declStatement | blockStatement | expressionStatement
      * </pre>
+     * @return a {@link Node} or {@code null}
      */
     private Node parseStatement() {
-        if (match("return")) return parseReturn();
-        else if (match("int")) return parseDecl();
-        else if (match("{")) return parseBlock(true);
-        else if (match("#showGraph")) return showGraph();
+        if (matchx("return")  ) return parseReturn();
+        else if (matchx("int")) return parseDecl();
+        else if (match ("{"  )) return require(parseBlock(),"}");
+        else if (matchx("#showGraph")) return require(showGraph(),";");
         else return parseExpressionStatement();
     }
 
     /**
-     * Parses returnStatement; "return" already parsed
+     * Parses a return statement; "return" already parsed.
      *
      * <pre>
      *     'return' expr ;
      * </pre>
+     * @return an expression {@link Node}, never {@code null}
      */
     private Node parseReturn() {
         var expr = require(parseExpression(), ";");
-        return new ReturnNode(START, expr);
+        return new ReturnNode(START, expr).peephole();
     }
 
     /**
      * Dumps out the node graph
+     * @return {@code null}
      */
     private Node showGraph() {
-        require(";");
         System.out.println(new GraphVisualizer().generateDotOutput(this));
         return null;
     }
@@ -113,6 +126,7 @@ public class Parser {
      * <pre>
      *     name '=' expression ';'
      * </pre>
+     * @return an expression {@link Node}, never {@code null}
      */
     private Node parseExpressionStatement() {
         var name = requireId();
@@ -129,6 +143,7 @@ public class Parser {
      * <pre>
      *     'int' name = expression ';'
      * </pre>
+     * @return an expression {@link Node}, never {@code null}
      */
     private Node parseDecl() {
         // Type is 'int' for now
@@ -146,8 +161,9 @@ public class Parser {
      * <pre>
      *     expr : additiveExpr
      * </pre>
+     * @return an expression {@link Node}, never {@code null}
      */
-    private Node parseExpression() {return parseAddition();}
+    private Node parseExpression() { return parseAddition(); }
 
     /**
      * Parse an additive expression
@@ -155,6 +171,7 @@ public class Parser {
      * <pre>
      *     additiveExpr : multiplicativeExpr (('+' | '-') multiplicativeExpr)*
      * </pre>
+     * @return an add expression {@link Node}, never {@code null}
      */
     private Node parseAddition() {
         var lhs = parseMultiplication();
@@ -169,6 +186,7 @@ public class Parser {
      * <pre>
      *     multiplicativeExpr : unaryExpr (('*' | '/') unaryExpr)*
      * </pre>
+     * @return a multiply expression {@link Node}, never {@code null}
      */
     private Node parseMultiplication() {
         var lhs = parseUnary();
@@ -183,6 +201,7 @@ public class Parser {
      * <pre>
      *     unaryExpr : ('-') unaryExpr | primaryExpr
      * </pre>
+     * @return a unary expression {@link Node}, never {@code null}
      */
     private Node parseUnary() {
         if (match("-")) return new MinusNode(parseUnary()).peephole();
@@ -195,15 +214,16 @@ public class Parser {
      * <pre>
      *     primaryExpr : integerLiteral | Identifier | '(' expression ')'
      * </pre>
+     * @return a primary {@link Node}, never {@code null}
      */
     private Node parsePrimary() {
-        if (_lexer.isNumber()) return parseIntegerLiteral();
-        if (match("(")) return require(parseExpression(), ")");
-        String name = requireId();
-        Node id = _scope.lookup(name);
-        if( id==null )
-            throw error("Undefined name '" + name + "'");
-        return id;
+        if( _lexer.isNumber() ) return parseIntegerLiteral();
+        if( match("(") ) return require(parseExpression(), ")");
+        String name = _lexer.matchId();
+        if( name == null) throw errorSyntax("an identifier or expression");
+        Node n = _scope.lookup(name);
+        if( n!=null ) return n;
+        throw error("Undefined name '" + name + "'");
     }
 
     /**
@@ -221,17 +241,21 @@ public class Parser {
     // Utilities for lexical analysis
 
     // Return true and skip if "syntax" is next in the stream.
-    private boolean match(String syntax) {return _lexer.match(syntax);}
+    private boolean match (String syntax) { return _lexer.match (syntax); }
+    // Match must be "exact", not be followed by more id letters
+    private boolean matchx(String syntax) { return _lexer.matchx(syntax); }
+    // Return true and do NOT skip if 'ch' is next
+    private boolean peek(char ch) { return _lexer.peek(ch); }
 
     // Require and return an identifier
     private String requireId() {
         String id = _lexer.matchId();
-        if (id != null) return id;
-        throw error("identifier");
+        if (id != null && !KEYWORDS.contains(id) ) return id;
+        throw error("Expected an identifier, found '"+id+"'");
     }
 
     // Require an exact match
-    private void require(String syntax) {require(null, syntax);}
+    private void require(String syntax) { require(null, syntax); }
     private Node require(Node n, String syntax) {
         if (match(syntax)) return n;
         throw errorSyntax(syntax);
@@ -313,11 +337,24 @@ public class Parser {
             int len = syntax.length();
             if (_position + len > _input.length) return false;
             for (int i = 0; i < len; i++)
-                if ((char) _input[_position + i] != syntax.charAt(i)) return false;
+                if ((char) _input[_position + i] != syntax.charAt(i))
+                    return false;
             _position += len;
             return true;
         }
 
+        boolean matchx(String syntax) {
+            if( !match(syntax) ) return false;
+            if( !isIdLetter(peek()) ) return true;
+            _position -= syntax.length();
+            return false;
+        }
+
+        private boolean peek(char ch) {
+            skipWhiteSpace();
+            return peek()==ch;
+        }
+        
         // Return an identifier or null
         String matchId() {
             skipWhiteSpace();
@@ -341,7 +378,7 @@ public class Parser {
             String snum = new String(_input, start, --_position - start);
             if (snum.length() > 1 && snum.charAt(0) == '0')
                 throw error("Syntax error: integer values cannot start with '0'");
-            return new TypeInteger(Long.parseLong(snum));
+            return TypeInteger.constant(Long.parseLong(snum));
         }
 
         // First letter of an identifier 
@@ -367,8 +404,7 @@ public class Parser {
 
         private String parsePunctuation() {
             int start = _position;
-            if (isPunctuation(nextChar())) ;
-            return new String(_input, start, --_position - start);
+            return new String(_input, start, 1);
         }
     }
 

--- a/chapter03/src/main/java/com/seaofnodes/simple/node/AddNode.java
+++ b/chapter03/src/main/java/com/seaofnodes/simple/node/AddNode.java
@@ -3,17 +3,16 @@ package com.seaofnodes.simple.node;
 import com.seaofnodes.simple.type.*;
 
 public class AddNode extends Node {
-    public AddNode(Node lhs, Node rhs) {
-        super(null, lhs, rhs);
-    }
+    public AddNode(Node lhs, Node rhs) { super(null, lhs, rhs); }
+
+    @Override public String label() { return "Add"; }
+    
+    @Override public String glabel() { return "+"; }
 
     @Override
-    public String label() { return "Add"; }
-
-    @Override
-    StringBuilder _print(StringBuilder sb) {
-        in(1)._print(sb.append("("));
-        in(2)._print(sb.append("+"));
+    StringBuilder _print1(StringBuilder sb) {
+        in(1)._print0(sb.append("("));
+        in(2)._print0(sb.append("+"));
         return sb.append(")");
     }
   
@@ -21,8 +20,9 @@ public class AddNode extends Node {
     @Override
     public Type compute() {
         if( in(1)._type instanceof TypeInteger i0 &&
-            in(2)._type instanceof TypeInteger i1 )
-            return new TypeInteger(i0._con + i1._con);
+            in(2)._type instanceof TypeInteger i1 ) {
+            return TypeInteger.constant(i0.value()+i1.value());
+        }
         return TypeBot.BOTTOM;
     }
 

--- a/chapter03/src/main/java/com/seaofnodes/simple/node/ConstantNode.java
+++ b/chapter03/src/main/java/com/seaofnodes/simple/node/ConstantNode.java
@@ -16,25 +16,25 @@ import com.seaofnodes.simple.type.Type;
  * The Constant's value is the value stored in it.
  */
 public class ConstantNode extends Node {
-
+    Type _con;
     public ConstantNode( Type type ) {
         super(Parser.START);
-        _type = type;
+        _con = type;
     }
     
     @Override
-    public String label() { return "#"+_type; }
+    public String label() { return "#"+_con; }
   
     @Override
     public String uniqueName() { return "Con_" + _nid; }
 
     @Override
-    StringBuilder _print(StringBuilder sb) {
-        return _type._print(sb);
+    StringBuilder _print1(StringBuilder sb) {
+        return _con._print(sb);
     }
     
     @Override
-    public Type compute() { return _type; }
+    public Type compute() { return _con; }
 
     @Override
     public Node idealize() { return null; }

--- a/chapter03/src/main/java/com/seaofnodes/simple/node/Control.java
+++ b/chapter03/src/main/java/com/seaofnodes/simple/node/Control.java
@@ -1,9 +1,0 @@
-package com.seaofnodes.simple.node;
-
-
-/**
- * Control interface is a marker interface to be implemented
- * by Control nodes.
- */
-public interface Control {
-}

--- a/chapter03/src/main/java/com/seaofnodes/simple/node/DivNode.java
+++ b/chapter03/src/main/java/com/seaofnodes/simple/node/DivNode.java
@@ -5,17 +5,16 @@ import com.seaofnodes.simple.type.TypeBot;
 import com.seaofnodes.simple.type.TypeInteger;
 
 public class DivNode extends Node {
-    public DivNode(Node lhs, Node rhs) {
-        super(null, lhs, rhs);
-    }
+    public DivNode(Node lhs, Node rhs) { super(null, lhs, rhs); }
+
+    @Override public String label() { return "Div"; }
+
+    @Override public String glabel() { return "//"; }
 
     @Override
-    public String label() { return "Div"; }
-  
-    @Override
-    StringBuilder _print(StringBuilder sb) {
-        in(1)._print(sb.append("("));
-        in(2)._print(sb.append("/"));
+    StringBuilder _print1(StringBuilder sb) {
+        in(1)._print0(sb.append("("));
+        in(2)._print0(sb.append("/"));
         return sb.append(")");
     }
   
@@ -23,11 +22,9 @@ public class DivNode extends Node {
     public Type compute() {
         if (in(1)._type instanceof TypeInteger i0 &&
             in(2)._type instanceof TypeInteger i1) {
-            if (i0.isConstant() && i1.isConstant())
-                return i1._con == 0
-                    ? TypeInteger.ZERO
-                    : new TypeInteger(i0._con/i1._con);
-            return new TypeInteger(i0._con / i1._con);
+            return i1.value() == 0
+                ? TypeInteger.ZERO
+                : TypeInteger.constant(i0.value()/i1.value());
         }
         return TypeBot.BOTTOM;
     }

--- a/chapter03/src/main/java/com/seaofnodes/simple/node/MinusNode.java
+++ b/chapter03/src/main/java/com/seaofnodes/simple/node/MinusNode.java
@@ -5,23 +5,22 @@ import com.seaofnodes.simple.type.TypeBot;
 import com.seaofnodes.simple.type.TypeInteger;
 
 public class MinusNode extends Node {
-    public MinusNode(Node in) {
-        super(null, in);
-    }
+    public MinusNode(Node in) { super(null, in); }
 
-    @Override
-    public String label() { return "Minus"; }
+    @Override public String label() { return "Minus"; }
+  
+    @Override public String glabel() { return "-"; }
   
     @Override
-    StringBuilder _print(StringBuilder sb) {
-        in(1)._print(sb.append("(-"));
+    StringBuilder _print1(StringBuilder sb) {
+        in(1)._print0(sb.append("(-"));
         return sb.append(")");
     }
   
     @Override
     public Type compute() {
         if (in(1)._type instanceof TypeInteger i0)
-            return new TypeInteger(-i0._con);
+            return TypeInteger.constant(-i0.value());
         return TypeBot.BOTTOM;
     }
 

--- a/chapter03/src/main/java/com/seaofnodes/simple/node/MulNode.java
+++ b/chapter03/src/main/java/com/seaofnodes/simple/node/MulNode.java
@@ -5,25 +5,25 @@ import com.seaofnodes.simple.type.TypeBot;
 import com.seaofnodes.simple.type.TypeInteger;
 
 public class MulNode extends Node {
-    public MulNode(Node lhs, Node rhs) {
-        super(null, lhs, rhs);
-    }
+    public MulNode(Node lhs, Node rhs) { super(null, lhs, rhs); }
+
+    @Override public String label() { return "Mul"; }
   
+    @Override public String glabel() { return "*"; }
+
     @Override
-    public String label() { return "Mul"; }
-  
-    @Override
-    StringBuilder _print(StringBuilder sb) {
-        in(1)._print(sb.append("("));
-        in(2)._print(sb.append("*"));
+    StringBuilder _print1(StringBuilder sb) {
+        in(1)._print0(sb.append("("));
+        in(2)._print0(sb.append("*"));
         return sb.append(")");
     }
-  
+
     @Override
     public Type compute() {
         if (in(1)._type instanceof TypeInteger i0 &&
-                in(2)._type instanceof TypeInteger i1)
-            return new TypeInteger(i0._con * i1._con);
+            in(2)._type instanceof TypeInteger i1) {
+            return TypeInteger.constant(i0.value()*i1.value());
+        }
         return TypeBot.BOTTOM;
     }
 

--- a/chapter03/src/main/java/com/seaofnodes/simple/node/ReturnNode.java
+++ b/chapter03/src/main/java/com/seaofnodes/simple/node/ReturnNode.java
@@ -1,6 +1,6 @@
 package com.seaofnodes.simple.node;
 
-import com.seaofnodes.simple.type.TypeBot;
+import com.seaofnodes.simple.type.*;
 
 /**
  * The Return node has two inputs.  The first input is a control node and the
@@ -11,7 +11,7 @@ import com.seaofnodes.simple.type.TypeBot;
  * <p>
  * The Return's output is the value from the data node.
  */
-public class ReturnNode extends Node implements Control {
+public class ReturnNode extends Node {
 
     public ReturnNode(Node ctrl, Node data) {
         super(ctrl, data);
@@ -24,10 +24,11 @@ public class ReturnNode extends Node implements Control {
     public String label() { return "Return"; }
 
     @Override
-    StringBuilder _print(StringBuilder sb) {
-        return expr()._print(sb.append("return ")).append(";");
+    StringBuilder _print1(StringBuilder sb) {
+        return expr()._print0(sb.append("return ")).append(";");
     }
 
+    @Override public boolean isCFG() { return true; }
   
     @Override
     public TypeBot compute() {

--- a/chapter03/src/main/java/com/seaofnodes/simple/node/StartNode.java
+++ b/chapter03/src/main/java/com/seaofnodes/simple/node/StartNode.java
@@ -3,11 +3,13 @@ package com.seaofnodes.simple.node;
 import com.seaofnodes.simple.type.TypeBot;
 
 /**
- * The Start node represents the start of the function.  For now, we do not have any inputs to Start because our function does not
- * yet accept parameters.  When we add parameters the value of Start will be a tuple, and will require Projections to extract the values.
- * We discuss this in detail in Chapter 9: Functions and Calls.
+ * The Start node represents the start of the function.  For now, we do not
+ * have any inputs to Start because our function does not yet accept
+ * parameters.  When we add parameters the value of Start will be a tuple, and
+ * will require Projections to extract the values.  We discuss this in detail
+ * in Chapter 9: Functions and Calls.
  */
-public class StartNode extends Node implements Control {
+public class StartNode extends Node {
 
     public StartNode(/*arguments go here*/) {
         super();
@@ -17,10 +19,12 @@ public class StartNode extends Node implements Control {
     public String label() { return "Start"; }
 
     @Override
-    StringBuilder _print(StringBuilder sb) {
+    StringBuilder _print1(StringBuilder sb) {
       return sb.append(label());
     }
-  
+
+    @Override public boolean isCFG() { return true; }
+
     @Override
     public TypeBot compute() {
         return TypeBot.BOTTOM;

--- a/chapter03/src/main/java/com/seaofnodes/simple/node/SubNode.java
+++ b/chapter03/src/main/java/com/seaofnodes/simple/node/SubNode.java
@@ -5,25 +5,25 @@ import com.seaofnodes.simple.type.TypeBot;
 import com.seaofnodes.simple.type.TypeInteger;
 
 public class SubNode extends Node {
-    public SubNode(Node lhs, Node rhs) {
-        super(null, lhs, rhs);
-    }
+    public SubNode(Node lhs, Node rhs) { super(null, lhs, rhs); }
+
+    @Override public String label() { return "Sub"; }
+
+    @Override public String glabel() { return "-"; }
 
     @Override
-    public String label() { return "Sub"; }
-
-    @Override
-    StringBuilder _print(StringBuilder sb) {
-        in(1)._print(sb.append("("));
-        in(2)._print(sb.append("-"));
+    StringBuilder _print1(StringBuilder sb) {
+        in(1)._print0(sb.append("("));
+        in(2)._print0(sb.append("-"));
         return sb.append(")");
     }
   
     @Override
     public Type compute() {
         if (in(1)._type instanceof TypeInteger i0 &&
-                in(2)._type instanceof TypeInteger i1)
-            return new TypeInteger(i0._con - i1._con);
+            in(2)._type instanceof TypeInteger i1) {
+            return TypeInteger.constant(i0.value()-i1.value());
+        }
         return TypeBot.BOTTOM;
     }
 

--- a/chapter03/src/main/java/com/seaofnodes/simple/type/TypeBot.java
+++ b/chapter03/src/main/java/com/seaofnodes/simple/type/TypeBot.java
@@ -8,7 +8,7 @@ public class TypeBot extends Type {
   
     @Override
     public String toString() { return "Bottom"; }
-  
-    @Override 
+
+    @Override
     public StringBuilder _print(StringBuilder sb) { return sb.append(toString()); }
 }

--- a/chapter03/src/main/java/com/seaofnodes/simple/type/TypeInteger.java
+++ b/chapter03/src/main/java/com/seaofnodes/simple/type/TypeInteger.java
@@ -14,6 +14,8 @@ public class TypeInteger extends Type {
 
     public TypeInteger(long con) { _con = con; }
 
+    public static TypeInteger constant(long con) { return new TypeInteger(con); }
+
     @Override
     public String toString() {
       return _print(new StringBuilder()).toString();
@@ -25,7 +27,7 @@ public class TypeInteger extends Type {
     @Override
     public boolean isConstant() { return true; }
 
-    public long getConstant() { return _con; }
+    public long value() { return _con; }
 
     @Override
     public boolean equals( Object o ) {

--- a/chapter03/src/test/java/com/seaofnodes/simple/Chapter03Test.java
+++ b/chapter03/src/test/java/com/seaofnodes/simple/Chapter03Test.java
@@ -1,16 +1,12 @@
 package com.seaofnodes.simple;
 
-import com.seaofnodes.simple.node.ConstantNode;
-import com.seaofnodes.simple.node.Node;
-import com.seaofnodes.simple.node.ReturnNode;
-import com.seaofnodes.simple.node.StartNode;
+import com.seaofnodes.simple.node.*;
 import com.seaofnodes.simple.type.TypeInteger;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
 public class Chapter03Test {
 
@@ -54,6 +50,15 @@ public class Chapter03Test {
         assertEquals("return 8;", ret.print());
     }
 
+    @Test
+    public void testSelfAssign() {
+        try { 
+            new Parser("int a=a; return a;").parse();
+            fail();
+        } catch( RuntimeException e ) {
+            assertEquals("Undefined name 'a'",e.getMessage());
+        }
+    }
 
     @Test
     public void testChapter2ParseGrammar() {
@@ -120,7 +125,7 @@ public class Chapter03Test {
         Node expr = ret.expr();
         if( expr instanceof ConstantNode con ) {
             assertEquals(start,con.in(0));
-            assertEquals(new TypeInteger(1), con._type);
+            assertEquals(TypeInteger.constant(1), con._type);
         } else {
             fail();
         }
@@ -133,21 +138,27 @@ public class Chapter03Test {
         StartNode start = Parser.START;
         for( Node use : start._outputs )
             if( use instanceof ConstantNode con )
-                assertEquals(new TypeInteger(0),con._type);
+                assertEquals(TypeInteger.constant(0),con._type);
     }
 
     @Test
     public void testBad1() {
-        exceptionRule.expect(RuntimeException.class);
-        exceptionRule.expectMessage("Syntax error, expected =: ");
-        new Parser("ret").parse();
+        try { 
+            new Parser("ret").parse();
+            fail();
+        } catch( RuntimeException e ) {
+            assertEquals("Syntax error, expected =: ",e.getMessage());
+        }
     }
 
     @Test
     public void testBad2() {
-        exceptionRule.expect(RuntimeException.class);
-        exceptionRule.expectMessage("Syntax error: integer values cannot start with '0'");
-        new Parser("return 0123;").parse();
+        try { 
+            new Parser("return 0123;").parse();
+            fail();
+        } catch( RuntimeException e ) {
+            assertEquals("Syntax error: integer values cannot start with '0'",e.getMessage());
+        }
     }
 
     @Test
@@ -158,9 +169,12 @@ public class Chapter03Test {
 
     @Test
     public void testBad4() {
-        exceptionRule.expect(RuntimeException.class);
-        exceptionRule.expectMessage("Syntax error, expected ;:");
-        new Parser("return 100").parse();
+        try { 
+            new Parser("return 100").parse();
+            fail();
+        } catch( RuntimeException e ) {
+            assertEquals("Syntax error, expected ;: ",e.getMessage());
+        }
     }
 
     @Test
@@ -171,8 +185,11 @@ public class Chapter03Test {
 
     @Test
     public void testBad6() {
-        exceptionRule.expect(RuntimeException.class);
-        exceptionRule.expectMessage("Syntax error, expected }:");
-        new Parser("int a=1; int b=2; int c=0; { int b=3; c=a+b;").parse();
+        try {
+            new Parser("int a=1; int b=2; int c=0; { int b=3; c=a+b;").parse();
+            fail();
+        } catch( RuntimeException e ) {
+            assertEquals("Syntax error, expected }: ",e.getMessage());
+        }
     }
 }

--- a/chapter04/src/main/java/com/seaofnodes/simple/GraphVisualizer.java
+++ b/chapter04/src/main/java/com/seaofnodes/simple/GraphVisualizer.java
@@ -1,7 +1,6 @@
 package com.seaofnodes.simple;
 
 import com.seaofnodes.simple.node.*;
-import com.seaofnodes.simple.type.TypeControl;
 
 import java.util.*;
 
@@ -29,6 +28,13 @@ public class GraphVisualizer {
         // scopes and nodes.  If we try to cross subgraph cluster borders while
         // still making the subgraphs DOT gets confused.
         sb.append("\trankdir=BT;\n"); // Force Nodes before Scopes
+
+        // Preserve node input order
+        sb.append("\tordering=\"in\";\n");
+
+        // Merge multiple edges hitting the same node.  Makes common shared
+        // nodes much prettier to look at.
+        sb.append("\tconcentrate=\"true\";\n");
         
         // Just the Nodes first, in a cluster no edges
         nodes(sb, all);
@@ -51,10 +57,10 @@ public class GraphVisualizer {
         // Just the Nodes first, in a cluster no edges
         sb.append("\tsubgraph cluster_Nodes {\n"); // Magic "cluster_" in the subgraph name
         for( Node n : all ) {
-            if( n instanceof ProjNode )
-                continue; // Do not emit, rolled into MultiNode already
+            if( n instanceof ProjNode || n instanceof ScopeNode )
+                continue; // Do not emit, rolled into MultiNode or Scope cluster already
             sb.append("\t\t").append(n.uniqueName()).append(" [ ");
-            String lab = n.label();
+            String lab = n.glabel();
             if( n instanceof MultiNode ) {
                 // Make a box with the MultiNode on top, and all the projections on the bottom
                 sb.append("shape=plaintext label=<\n");
@@ -71,8 +77,8 @@ public class GraphVisualizer {
                             sb.append("\t\t\t\t<TR>");
                         }
                         sb.append("<TD PORT=\"p").append(proj._idx).append("\"");
-                        if( proj._idx==0 ) sb.append(" BGCOLOR=\"yellow\"");
-                        sb.append(">").append(proj.label()).append("</TD>");
+                        if( proj.isCFG() ) sb.append(" BGCOLOR=\"yellow\"");
+                        sb.append(">").append(proj.glabel()).append("</TD>");
                     }
                 }
                 if (doProjTable) {
@@ -86,7 +92,7 @@ public class GraphVisualizer {
             } else {
                 // control nodes have box shape
                 // other nodes are ellipses, i.e. default shape
-                if( n instanceof Control )
+                if( n.isCFG() )
                     sb.append("shape=box style=filled fillcolor=yellow ");
                 sb.append("label=\"").append(lab).append("\" ");
             }
@@ -99,8 +105,8 @@ public class GraphVisualizer {
         sb.append("\tnode [shape=plaintext];\n");
         int level=0;
         for( HashMap<String,Integer> scope : scopenode._scopes ) {
-            sb.append("\tsubgraph cluster_").append(level).append(" {\n"); // Magic "cluster_" in the subgraph name
-            String scopeName = makeScopeName(level);
+            String scopeName = makeScopeName(scopenode, level);
+            sb.append("\tsubgraph cluster_").append(scopeName).append(" {\n"); // Magic "cluster_" in the subgraph name
             sb.append("\t\t").append(scopeName).append(" [label=<\n");
             sb.append("\t\t\t<TABLE BORDER=\"0\" CELLBORDER=\"1\" CELLSPACING=\"0\">\n");
             // Add the scope level
@@ -116,31 +122,38 @@ public class GraphVisualizer {
         // We close them all at once here.
         sb.append( "\t}\n".repeat( level ) ); // End all Scope clusters
     }
-    
-    private String makeScopeName(int level) { return "scope" + level; }
-    private String makePortName(String scopeName, String varName) { return scopeName + "_" + varName; }
 
-    private boolean isControlEdge(Node def) {
-        return def._type instanceof TypeControl;
-    }
+    private String makeScopeName(ScopeNode sn, int level) { return sn.uniqueName() + "_" + level; }
+    private String makePortName(String scopeName, String varName) { return scopeName + "_" + varName; }
 
     // Walk the node edges
     private void nodeEdges(StringBuilder sb, Collection<Node> all) {
+        // All them edge labels
+        sb.append("\tedge [ fontname=Helvetica, fontsize=8 ];\n");
         for( Node n : all ) {
-            if( n instanceof ConstantNode || n instanceof ProjNode )
-                continue;       // Do not display the Constant->Start edge; ProjNodes handled by Multi
-            for( Node def : n._inputs )
+            // Do not display the Constant->Start edge;
+            // ProjNodes handled by Multi;
+            // ScopeNodes are done separately
+            if( n instanceof ConstantNode || n instanceof ProjNode || n instanceof ScopeNode )
+                continue;
+            int i=0;
+            for( Node def : n._inputs ) {
                 if( def != null ) {
+                    // Most edges land here use->def
                     sb.append('\t').append(n.uniqueName()).append(" -> ");
                     if( def instanceof ProjNode proj ) {
                         String mname = proj.ctrl().uniqueName();
                         sb.append(mname).append(":p").append(proj._idx);
                     } else sb.append(def.uniqueName());
-                    // Control edges are colored red
-                    if( isControlEdge(def) )
-                        sb.append(" [color=red]");
-                    sb.append(";\n");
+                    // Number edges, so we can see how they track
+                    sb.append("[taillabel=").append(i);
+                    // control edges are colored red
+                    if( def.isCFG() )
+                        sb.append("; color=red");
+                    sb.append("];\n");
                 }
+                i++;
+            }
         }
     }
     
@@ -149,7 +162,7 @@ public class GraphVisualizer {
         sb.append("\tedge [style=dashed color=cornflowerblue];\n");
         int level=0;
         for( HashMap<String,Integer> scope : scopenode._scopes ) {
-            String scopeName = makeScopeName(level);
+            String scopeName = makeScopeName(scopenode, level);
             for( String name : scope.keySet() ) {
                 Node def = scopenode.in(scope.get(name));
                 if( def==null ) continue;

--- a/chapter04/src/main/java/com/seaofnodes/simple/Parser.java
+++ b/chapter04/src/main/java/com/seaofnodes/simple/Parser.java
@@ -15,6 +15,12 @@ import java.util.*;
 public class Parser {
 
     /**
+     * The control is a name that binds to the currently active control
+     * node in the graph
+     */
+    public static final String CTRL = "$ctrl";
+  
+    /**
      * A Global Static, unique to each compilation.  This is a public, so we
      * can make constants everywhere without having to thread the StartNode
      * through the entire parser and optimizer.
@@ -23,6 +29,7 @@ public class Parser {
      */
     public static StartNode START;
 
+    // The Lexer.  Thin wrapper over a byte[] buffer with a cursor.
     private final Lexer _lexer;
 
     /**
@@ -31,10 +38,19 @@ public class Parser {
      */
     public ScopeNode _scope;
 
+    /**
+     * List of keywords disallowed as identifiers
+     */
+    private final HashSet<String> KEYWORDS = new HashSet<>(){{
+            add("int");
+            add("return");
+        }};
+
+
     public Parser(String source, TypeInteger arg) {
         _lexer = new Lexer(source);
-        _scope = new ScopeNode();
         Node.reset();
+        _scope = new ScopeNode();
         START = new StartNode(new Type[]{ Type.CONTROL, arg });
         START.peephole();
     }
@@ -45,17 +61,21 @@ public class Parser {
 
     String src() { return new String( _lexer._input ); }
 
+    private Node ctrl() { return _scope.ctrl(); }
 
+    private Node ctrl(Node n) { return _scope.ctrl(n); }
 
-    public ReturnNode parse() {
+    public ReturnNode parse() { return parse(false); }
+    public ReturnNode parse(boolean show) {
         _scope.push();
         try {
-            _scope.define("$ctrl", new ProjNode(START, 0, "$ctrl").peephole());
-            _scope.define("arg"  , new ProjNode(START, 1, "arg"  ).peephole());
-            return (ReturnNode) parseBlock(false);
+            _scope.define(CTRL , new ProjNode(START, 0, CTRL ).peephole());
+            _scope.define("arg", new ProjNode(START, 1, "arg").peephole());
+            return (ReturnNode) parseBlock();
         }
         finally {
             _scope.pop();
+            if( show ) showGraph();
         }
     }
 
@@ -65,23 +85,17 @@ public class Parser {
      * <pre>
      *     '{' statements '}'
      * </pre>
+     * Does not parse the opening or closing '{}'
+     * @return a {@link Node} or {@code null}
      */
-    private Node parseBlock(boolean requireClosingBracket) {
+    private Node parseBlock() {
         // Enter a new scope
         _scope.push();
         Node n = null;
-        do {
-            if (match("}")) {
-                if (requireClosingBracket) break;
-                else throw error("unexpected '}' token");
-            } else if (_lexer.isEOF()) {
-                if (requireClosingBracket) require("}");
-                else break;
-            }
-
+        while (!peek('}') && !_lexer.isEOF()) {
             Node n0 = parseStatement();
             if (n0 != null) n = n0; // Allow null returns from eg showGraph
-        } while (true);
+        };
         // Exit scope
         _scope.pop();
         return n;
@@ -93,12 +107,13 @@ public class Parser {
      * <pre>
      *     returnStatement | declStatement | blockStatement | expressionStatement
      * </pre>
+     * @return a {@link Node} or {@code null}
      */
     private Node parseStatement() {
-        if (match("return")) return parseReturn();
-        else if (match("int")) return parseDecl();
-        else if (match("{")) return parseBlock(true);
-        else if (match("#showGraph")) return showGraph();
+        if (matchx("return")  ) return parseReturn();
+        else if (matchx("int")) return parseDecl();
+        else if (match ("{"  )) return require(parseBlock(),"}");
+        else if (matchx("#showGraph")) return require(showGraph(),";");
         else return parseExpressionStatement();
     }
 
@@ -109,19 +124,20 @@ public class Parser {
      * <pre>
      *     'return' expr ;
      * </pre>
+     * @return an expression {@link Node}, never {@code null}
      */
     private Node parseReturn() {
         var expr = require(parseExpression(), ";");
-        Node ret = new ReturnNode(_scope.lookup("$ctrl"), expr);
-        _scope.update("$ctrl",null);
+        Node ret = new ReturnNode(ctrl(), expr).peephole();
+        ctrl(null);             // Kill control
         return ret;
     }
 
     /**
      * Dumps out the node graph
+     * @return {@code null}
      */
     private Node showGraph() {
-        require(";");
         System.out.println(new GraphVisualizer().generateDotOutput(this));
         return null;
     }
@@ -132,6 +148,7 @@ public class Parser {
      * <pre>
      *     name '=' expression ';'
      * </pre>
+     * @return an expression {@link Node}, never {@code null}
      */
     private Node parseExpressionStatement() {
         var name = requireId();
@@ -148,6 +165,7 @@ public class Parser {
      * <pre>
      *     'int' name = expression ';'
      * </pre>
+     * @return an expression {@link Node}, never {@code null}
      */
     private Node parseDecl() {
         // Type is 'int' for now
@@ -163,11 +181,20 @@ public class Parser {
      * Parse an expression of the form:
      *
      * <pre>
-     *     expr : additiveExpr
+     *     expr : compareExpr
      * </pre>
+     * @return an expression {@link Node}, never {@code null}
      */
     private Node parseExpression() { return parseComparison(); }
 
+    /**
+     * Parse an expression of the form:
+     *
+     * <pre>
+     *     expr : additiveExpr op additiveExpr
+     * </pre>
+     * @return an comparator expression {@link Node}, never {@code null}
+     */
     private Node parseComparison() {
         var lhs = parseAddition();
         if (match("==")) return new BoolNode.EQNode(lhs, parseComparison()).peephole();
@@ -185,6 +212,7 @@ public class Parser {
      * <pre>
      *     additiveExpr : multiplicativeExpr (('+' | '-') multiplicativeExpr)*
      * </pre>
+     * @return an add expression {@link Node}, never {@code null}
      */
     private Node parseAddition() {
         var lhs = parseMultiplication();
@@ -199,6 +227,7 @@ public class Parser {
      * <pre>
      *     multiplicativeExpr : unaryExpr (('*' | '/') unaryExpr)*
      * </pre>
+     * @return a multiply expression {@link Node}, never {@code null}
      */
     private Node parseMultiplication() {
         var lhs = parseUnary();
@@ -213,6 +242,7 @@ public class Parser {
      * <pre>
      *     unaryExpr : ('-') unaryExpr | primaryExpr
      * </pre>
+     * @return a unary expression {@link Node}, never {@code null}
      */
     private Node parseUnary() {
         if (match("-")) return new MinusNode(parseUnary()).peephole();
@@ -225,15 +255,16 @@ public class Parser {
      * <pre>
      *     primaryExpr : integerLiteral | Identifier | '(' expression ')'
      * </pre>
+     * @return a primary {@link Node}, never {@code null}
      */
     private Node parsePrimary() {
-        if (_lexer.isNumber()) return parseIntegerLiteral();
-        if (match("(")) return require(parseExpression(), ")");
-        String name = requireId();
-        Node id = _scope.lookup(name);
-        if( id==null )
-            throw error("Undefined name '" + name + "'");
-        return id.peephole();
+        if( _lexer.isNumber() ) return parseIntegerLiteral();
+        if( match("(") ) return require(parseExpression(), ")");
+        String name = _lexer.matchId();
+        if( name == null) throw errorSyntax("an identifier or expression");
+        Node n = _scope.lookup(name);
+        if( n!=null ) return n;
+        throw error("Undefined name '" + name + "'");
     }
 
     /**
@@ -251,13 +282,17 @@ public class Parser {
     // Utilities for lexical analysis
 
     // Return true and skip if "syntax" is next in the stream.
-    private boolean match(String syntax) { return _lexer.match(syntax); }
+    private boolean match (String syntax) { return _lexer.match (syntax); }
+    // Match must be "exact", not be followed by more id letters
+    private boolean matchx(String syntax) { return _lexer.matchx(syntax); }
+    // Return true and do NOT skip if 'ch' is next
+    private boolean peek(char ch) { return _lexer.peek(ch); }
 
     // Require and return an identifier
     private String requireId() {
         String id = _lexer.matchId();
-        if (id != null) return id;
-        throw error("identifier");
+        if (id != null && !KEYWORDS.contains(id) ) return id;
+        throw error("Expected an identifier, found '"+id+"'");
     }
 
     // Require an exact match
@@ -343,11 +378,24 @@ public class Parser {
             int len = syntax.length();
             if (_position + len > _input.length) return false;
             for (int i = 0; i < len; i++)
-                if ((char) _input[_position + i] != syntax.charAt(i)) return false;
+                if ((char) _input[_position + i] != syntax.charAt(i))
+                    return false;
             _position += len;
             return true;
         }
 
+        boolean matchx(String syntax) {
+            if( !match(syntax) ) return false;
+            if( !isIdLetter(peek()) ) return true;
+            _position -= syntax.length();
+            return false;
+        }
+
+        private boolean peek(char ch) {
+            skipWhiteSpace();
+            return peek()==ch;
+        }
+        
         // Return an identifier or null
         String matchId() {
             skipWhiteSpace();
@@ -397,8 +445,7 @@ public class Parser {
 
         private String parsePunctuation() {
             int start = _position;
-            if (isPunctuation(nextChar())) ;
-            return new String(_input, start, --_position - start);
+            return new String(_input, start, 1);
         }
     }
 

--- a/chapter04/src/main/java/com/seaofnodes/simple/node/BoolNode.java
+++ b/chapter04/src/main/java/com/seaofnodes/simple/node/BoolNode.java
@@ -13,7 +13,10 @@ abstract public class BoolNode extends Node {
     abstract String op();       // String opcode name
     
     @Override
-    public String label() { return op(); }
+    public String label() { return getClass().getSimpleName(); }
+
+    @Override
+    public String glabel() { return op(); }
 
     @Override
     StringBuilder _print1(StringBuilder sb) {

--- a/chapter04/src/main/java/com/seaofnodes/simple/node/Control.java
+++ b/chapter04/src/main/java/com/seaofnodes/simple/node/Control.java
@@ -1,9 +1,0 @@
-package com.seaofnodes.simple.node;
-
-
-/**
- * Control interface is a marker interface to be implemented
- * by Control nodes.
- */
-public interface Control {
-}

--- a/chapter04/src/main/java/com/seaofnodes/simple/node/DivNode.java
+++ b/chapter04/src/main/java/com/seaofnodes/simple/node/DivNode.java
@@ -5,13 +5,12 @@ import com.seaofnodes.simple.type.TypeBot;
 import com.seaofnodes.simple.type.TypeInteger;
 
 public class DivNode extends Node {
-    public DivNode(Node lhs, Node rhs) {
-        super(null, lhs, rhs);
-    }
+    public DivNode(Node lhs, Node rhs) { super(null, lhs, rhs); }
 
-    @Override
-    public String label() { return "Div"; }
-  
+    @Override public String label() { return "Div"; }
+
+    @Override public String glabel() { return "//"; }
+
     @Override
     StringBuilder _print1(StringBuilder sb) {
         in(1)._print0(sb.append("("));

--- a/chapter04/src/main/java/com/seaofnodes/simple/node/MinusNode.java
+++ b/chapter04/src/main/java/com/seaofnodes/simple/node/MinusNode.java
@@ -5,12 +5,11 @@ import com.seaofnodes.simple.type.TypeBot;
 import com.seaofnodes.simple.type.TypeInteger;
 
 public class MinusNode extends Node {
-    public MinusNode(Node in) {
-        super(null, in);
-    }
+    public MinusNode(Node in) { super(null, in); }
 
-    @Override
-    public String label() { return "Minus"; }
+    @Override public String label() { return "Minus"; }
+  
+    @Override public String glabel() { return "-"; }
   
     @Override
     StringBuilder _print1(StringBuilder sb) {

--- a/chapter04/src/main/java/com/seaofnodes/simple/node/MulNode.java
+++ b/chapter04/src/main/java/com/seaofnodes/simple/node/MulNode.java
@@ -5,12 +5,11 @@ import com.seaofnodes.simple.type.TypeBot;
 import com.seaofnodes.simple.type.TypeInteger;
 
 public class MulNode extends Node {
-    public MulNode(Node lhs, Node rhs) {
-        super(null, lhs, rhs);
-    }
+    public MulNode(Node lhs, Node rhs) { super(null, lhs, rhs); }
 
-    @Override
-    public String label() { return "Mul"; }
+    @Override public String label() { return "Mul"; }
+  
+    @Override public String glabel() { return "*"; }
 
     @Override
     StringBuilder _print1(StringBuilder sb) {
@@ -43,12 +42,8 @@ public class MulNode extends Node {
             return lhs;
         
         // Move constants to RHS: con*arg becomes arg*con
-        if ( t1.isConstant() && !t2.isConstant() ) {
-            Node tmp = in(1);   // Swap inputs without letting either input go dead during the swap
-            _inputs.set(1,in(2));
-            _inputs.set(2,tmp);
-            return this;
-        }
+        if ( t1.isConstant() && !t2.isConstant() )
+            return swap12();
         
         return null;
     }

--- a/chapter04/src/main/java/com/seaofnodes/simple/node/MultiNode.java
+++ b/chapter04/src/main/java/com/seaofnodes/simple/node/MultiNode.java
@@ -4,10 +4,6 @@ import com.seaofnodes.simple.type.Type;
 
 public abstract class MultiNode extends Node {
     
-    public MultiNode(Node... inputs) {
-        super(inputs);
-    }
-    
-    // Return the ProjNode with the idx
-    abstract ProjNode proj(int idx);
+    public MultiNode(Node... inputs) { super(inputs); }
+
 }

--- a/chapter04/src/main/java/com/seaofnodes/simple/node/ProjNode.java
+++ b/chapter04/src/main/java/com/seaofnodes/simple/node/ProjNode.java
@@ -22,7 +22,9 @@ public class ProjNode extends Node {
     public String label() { return _label; }
 
     @Override
-    StringBuilder _print1(StringBuilder sb) { return sb.append("Proj_" +_nid); }
+    StringBuilder _print1(StringBuilder sb) { return sb.append(_label); }
+
+    @Override public boolean isCFG() { return _idx==0; }
 
     public MultiNode ctrl() { return (MultiNode)in(0); }
 

--- a/chapter04/src/main/java/com/seaofnodes/simple/node/ReturnNode.java
+++ b/chapter04/src/main/java/com/seaofnodes/simple/node/ReturnNode.java
@@ -1,7 +1,6 @@
 package com.seaofnodes.simple.node;
 
-import com.seaofnodes.simple.type.Type;
-import com.seaofnodes.simple.type.TypeBot;
+import com.seaofnodes.simple.type.*;
 
 /**
  * The Return node has two inputs.  The first input is a control node and the
@@ -12,7 +11,7 @@ import com.seaofnodes.simple.type.TypeBot;
  * <p>
  * The Return's output is the value from the data node.
  */
-public class ReturnNode extends Node implements Control {
+public class ReturnNode extends Node {
 
     public ReturnNode(Node ctrl, Node data) {
         super(ctrl, data);
@@ -29,10 +28,11 @@ public class ReturnNode extends Node implements Control {
         return expr()._print0(sb.append("return ")).append(";");
     }
 
+    @Override public boolean isCFG() { return true; }
   
     @Override
     public Type compute() {
-        return expr().compute();
+      return new TypeTuple(TypeControl.CONTROL,expr()._type);
     }
 
     @Override

--- a/chapter04/src/main/java/com/seaofnodes/simple/node/StartNode.java
+++ b/chapter04/src/main/java/com/seaofnodes/simple/node/StartNode.java
@@ -11,7 +11,7 @@ import com.seaofnodes.simple.type.TypeTuple;
  * will require Projections to extract the values.  We discuss this in detail
  * in Chapter 9: Functions and Calls.
  */
-public class StartNode extends MultiNode implements Control {
+public class StartNode extends MultiNode {
 
     final TypeTuple _args;
     
@@ -27,20 +27,12 @@ public class StartNode extends MultiNode implements Control {
     StringBuilder _print1(StringBuilder sb) {
       return sb.append(label());
     }
-  
+
+    @Override public boolean isCFG() { return true; }
+
     @Override
     public TypeTuple compute() { return _args; }
 
     @Override
     public Node idealize() { return null; }
-
-    
-    @Override 
-    public ProjNode proj( int idx ) {
-        for( Node proj : _outputs )
-            if( ((ProjNode)proj)._idx==idx )
-                return (ProjNode)proj;
-        return null;
-    }
-  
 }

--- a/chapter04/src/main/java/com/seaofnodes/simple/node/SubNode.java
+++ b/chapter04/src/main/java/com/seaofnodes/simple/node/SubNode.java
@@ -5,12 +5,11 @@ import com.seaofnodes.simple.type.TypeBot;
 import com.seaofnodes.simple.type.TypeInteger;
 
 public class SubNode extends Node {
-    public SubNode(Node lhs, Node rhs) {
-        super(null, lhs, rhs);
-    }
+    public SubNode(Node lhs, Node rhs) { super(null, lhs, rhs); }
 
-    @Override
-    public String label() { return "Sub"; }
+    @Override public String label() { return "Sub"; }
+
+    @Override public String glabel() { return "-"; }
 
     @Override
     StringBuilder _print1(StringBuilder sb) {

--- a/chapter04/src/main/java/com/seaofnodes/simple/type/TypeInteger.java
+++ b/chapter04/src/main/java/com/seaofnodes/simple/type/TypeInteger.java
@@ -26,7 +26,7 @@ public class TypeInteger extends Type {
 
     @Override
     public String toString() {
-      return _print(new StringBuilder()).toString();
+        return _print(new StringBuilder()).toString();
     }
 
     @Override 

--- a/chapter04/src/main/java/com/seaofnodes/simple/type/TypeTuple.java
+++ b/chapter04/src/main/java/com/seaofnodes/simple/type/TypeTuple.java
@@ -1,10 +1,10 @@
 package com.seaofnodes.simple.type;
 
 public class TypeTuple extends Type {
-
+  
     public final Type[] _types;
 
-    public TypeTuple(Type[] _types) {
+    public TypeTuple(Type... _types) {
         this._types = _types;
     }
 

--- a/chapter04/src/test/java/com/seaofnodes/simple/Chapter04Test.java
+++ b/chapter04/src/test/java/com/seaofnodes/simple/Chapter04Test.java
@@ -15,44 +15,44 @@ public class Chapter04Test {
 
     @Test
     public void testChapter4Peephole() {
-        Parser parser = new Parser("return 1+arg+2; #showGraph;", TypeInteger.BOT);
+        Parser parser = new Parser("return 1+arg+2; #showGraph;");
         ReturnNode ret = parser.parse();
-        assertEquals("return (Proj_3+3);", ret.print());
+        assertEquals("return (arg+3);", ret.print());
     }
 
     @Test
     public void testChapter4Peephole2() {
-        Parser parser = new Parser("return (1+arg)+2;", TypeInteger.BOT);
+        Parser parser = new Parser("return (1+arg)+2;");
         ReturnNode ret = parser.parse();
-        assertEquals("return (Proj_3+3);", ret.print());
+        assertEquals("return (arg+3);", ret.print());
     }
 
     @Test
     public void testChapter4Add0() {
-        Parser parser = new Parser("return 0+arg;", TypeInteger.BOT);
+        Parser parser = new Parser("return 0+arg;");
         ReturnNode ret = parser.parse();
-        assertEquals("return Proj_3;", ret.print());
+        assertEquals("return arg;", ret.print());
     }
 
     @Test
     public void testChapter4AddAddMul() {
-        Parser parser = new Parser("return arg+0+arg;", TypeInteger.BOT);
+        Parser parser = new Parser("return arg+0+arg;");
         ReturnNode ret = parser.parse();
-        assertEquals("return (Proj_3*2);", ret.print());
+        assertEquals("return (arg*2);", ret.print());
     }
   
     @Test
     public void testChapter4Peephole3() {
-        Parser parser = new Parser("return 1+arg+2+arg+3; #showGraph;", TypeInteger.BOT);
+        Parser parser = new Parser("return 1+arg+2+arg+3; #showGraph;");
         ReturnNode ret = parser.parse();
-        assertEquals("return ((Proj_3*2)+6);", ret.print());
+        assertEquals("return ((arg*2)+6);", ret.print());
     }
 
     @Test
     public void testChapter4Mul1() {
-        Parser parser = new Parser("return 1*arg;", TypeInteger.BOT);
+        Parser parser = new Parser("return 1*arg;");
         ReturnNode ret = parser.parse();
-        assertEquals("return Proj_3;", ret.print());
+        assertEquals("return arg;", ret.print());
     }
   
     @Test
@@ -72,53 +72,56 @@ public class Chapter04Test {
 
     @Test
     public void testChapter4CompEq() {
-        Parser parser = new Parser("return 3==3; #showGraph;", TypeInteger.BOT);
+        Parser parser = new Parser("return 3==3; #showGraph;");
         ReturnNode ret = parser.parse();
         assertEquals("return 1;", ret.print());
     }
 
     @Test
     public void testChapter4CompEq2() {
-        Parser parser = new Parser("return 3==4; #showGraph;", TypeInteger.BOT);
+        Parser parser = new Parser("return 3==4; #showGraph;");
         ReturnNode ret = parser.parse();
         assertEquals("return 0;", ret.print());
     }
 
     @Test
     public void testChapter4CompNEq() {
-        Parser parser = new Parser("return 3!=3; #showGraph;", TypeInteger.BOT);
+        Parser parser = new Parser("return 3!=3; #showGraph;");
         ReturnNode ret = parser.parse();
         assertEquals("return 0;", ret.print());
     }
 
     @Test
     public void testChapter4CompNEq2() {
-        Parser parser = new Parser("return 3!=4; #showGraph;", TypeInteger.BOT);
+        Parser parser = new Parser("return 3!=4; #showGraph;");
         ReturnNode ret = parser.parse();
         assertEquals("return 1;", ret.print());
     }
 
     @Test
     public void testChapter4Bug1() {
-        Parser parser = new Parser("int a=arg+1; int b=a; b=1; return a+2; #showGraph;", TypeInteger.BOT);
+        Parser parser = new Parser("int a=arg+1; int b=a; b=1; return a+2; #showGraph;");
         ReturnNode ret = parser.parse();
-        assertEquals("return (Proj_3+3);", ret.print());
+        assertEquals("return (arg+3);", ret.print());
     }
 
     @Test
     public void testChapter4Bug2() {
-        Parser parser = new Parser("int a=arg+1; a=a; return a; #showGraph;", TypeInteger.BOT);
+        Parser parser = new Parser("int a=arg+1; a=a; return a; #showGraph;");
         ReturnNode ret = parser.parse();
-        assertEquals("return (Proj_3+1);", ret.print());
+        assertEquals("return (arg+1);", ret.print());
     }
 
     @Test
     public void testChapter4Bug3() {
-        Parser parser = new Parser("int a=arg*2+1; a=a+-1; return a; #showGraph;", TypeInteger.BOT);
-        ReturnNode ret = parser.parse();
-        assertEquals("return (Proj_3*2);", ret.print());
+        try { 
+            new Parser("inta=1; return a;").parse();
+            fail();
+        } catch( RuntimeException e ) {
+            assertEquals("Undefined name 'inta'",e.getMessage());
+        }
     }
-
+    
     @Test
     public void testVarDecl() {
         Parser parser = new Parser("int a=1; return a;");
@@ -158,11 +161,13 @@ public class Chapter04Test {
 
     @Test
     public void testSelfAssign() {
-        exceptionRule.expect(RuntimeException.class);
-        exceptionRule.expectMessage("Undefined name 'a'");
-        new Parser("int a=a; return a;").parse();
+        try { 
+            new Parser("int a=a; return a;").parse();
+            fail();
+        } catch( RuntimeException e ) {
+            assertEquals("Undefined name 'a'",e.getMessage());
+        }
     }
-
 
     @Test
     public void testChapter2ParseGrammar() {
@@ -247,16 +252,22 @@ public class Chapter04Test {
 
     @Test
     public void testBad1() {
-        exceptionRule.expect(RuntimeException.class);
-        exceptionRule.expectMessage("Syntax error, expected =: ");
-        new Parser("ret").parse();
+        try { 
+            new Parser("ret").parse();
+            fail();
+        } catch( RuntimeException e ) {
+            assertEquals("Syntax error, expected =: ",e.getMessage());
+        }
     }
 
     @Test
     public void testBad2() {
-        exceptionRule.expect(RuntimeException.class);
-        exceptionRule.expectMessage("Syntax error: integer values cannot start with '0'");
-        new Parser("return 0123;").parse();
+        try { 
+            new Parser("return 0123;").parse();
+            fail();
+        } catch( RuntimeException e ) {
+            assertEquals("Syntax error: integer values cannot start with '0'",e.getMessage());
+        }
     }
 
     @Test
@@ -267,9 +278,12 @@ public class Chapter04Test {
 
     @Test
     public void testBad4() {
-        exceptionRule.expect(RuntimeException.class);
-        exceptionRule.expectMessage("Syntax error, expected ;:");
-        new Parser("return 100").parse();
+        try { 
+            new Parser("return 100").parse();
+            fail();
+        } catch( RuntimeException e ) {
+            assertEquals("Syntax error, expected ;: ",e.getMessage());
+        }
     }
 
     @Test
@@ -280,8 +294,11 @@ public class Chapter04Test {
 
     @Test
     public void testBad6() {
-        exceptionRule.expect(RuntimeException.class);
-        exceptionRule.expectMessage("Syntax error, expected }:");
-        new Parser("int a=1; int b=2; int c=0; { int b=3; c=a+b;").parse();
+        try {
+            new Parser("int a=1; int b=2; int c=0; { int b=3; c=a+b;").parse();
+            fail();
+        } catch( RuntimeException e ) {
+            assertEquals("Syntax error, expected }: ",e.getMessage());
+        }
     }
 }

--- a/chapter05/src/main/java/com/seaofnodes/simple/GraphVisualizer.java
+++ b/chapter05/src/main/java/com/seaofnodes/simple/GraphVisualizer.java
@@ -146,7 +146,7 @@ public class GraphVisualizer {
     // Walk the node edges
     private void nodeEdges(StringBuilder sb, Collection<Node> all) {
         // All them edge labels
-	sb.append("\tedge [ fontname=Helvetica, fontsize=8 ];\n");
+        sb.append("\tedge [ fontname=Helvetica, fontsize=8 ];\n");
         for( Node n : all ) {
             // Do not display the Constant->Start edge;
             // ProjNodes handled by Multi;


### PR DESCRIPTION
This PR backports changes from chapter 5 to older chapters.
This includes

- Replace `Control` interface with `isCFG`. **Note**: This needs changes in some readme tests that refer to the removed marker interface.
- In chapter 2 & 3 move the type calculation into the peephole as it was calculated there anyway and call `peephole` on new nodes consitently.

This is a large changeset, but it tries to make the changes of the files between chapters as low as possible.