### PR TITLE
Add constant check to minus node

### DIFF
--- a/chapter04/src/main/java/com/seaofnodes/simple/node/MinusNode.java
+++ b/chapter04/src/main/java/com/seaofnodes/simple/node/MinusNode.java
@@ -20,7 +20,7 @@ public class MinusNode extends Node {
     @Override
     public Type compute() {
         if (in(1)._type instanceof TypeInteger i0)
-            return TypeInteger.constant(-i0.value());
+            return i0.isConstant() ? TypeInteger.constant(-i0.value()) : i0;
         return TypeBot.BOTTOM;
     }
 

--- a/chapter04/src/test/java/com/seaofnodes/simple/Chapter04Test.java
+++ b/chapter04/src/test/java/com/seaofnodes/simple/Chapter04Test.java
@@ -121,6 +121,13 @@ public class Chapter04Test {
             assertEquals("Undefined name 'inta'",e.getMessage());
         }
     }
+
+    @Test
+    public void testChapter4Bug4() {
+        Parser parser = new Parser("return -arg;");
+        ReturnNode ret = parser.parse();
+        assertEquals("return (-arg);", ret.print());
+    }
     
     @Test
     public void testVarDecl() {

--- a/chapter05/src/main/java/com/seaofnodes/simple/node/MinusNode.java
+++ b/chapter05/src/main/java/com/seaofnodes/simple/node/MinusNode.java
@@ -20,7 +20,7 @@ public class MinusNode extends Node {
     @Override
     public Type compute() {
         if (in(1)._type instanceof TypeInteger i0)
-            return TypeInteger.constant(-i0.value());
+            return i0.isConstant() ? TypeInteger.constant(-i0.value()) : i0;
         return TypeBot.BOTTOM;
     }
 

--- a/chapter05/src/test/java/com/seaofnodes/simple/Chapter05Test.java
+++ b/chapter05/src/test/java/com/seaofnodes/simple/Chapter05Test.java
@@ -259,6 +259,13 @@ return c;
             assertEquals("Undefined name 'inta'",e.getMessage());
         }
     }
+
+    @Test
+    public void testChapter4Bug4() {
+        Parser parser = new Parser("return -arg;");
+        StopNode ret = parser.parse();
+        assertEquals("return (-arg);", ret.print());
+    }
     
     @Test
     public void testVarDecl() {


### PR DESCRIPTION
The minus node did only check that the types are integers and then assumes they are constant which might not be the case with the addition of bottom and top. The problem occurres in statements such as `return -arg;` where the `-arg` is then replaced with the constant `-1` as the bottom type will return the value `1`.