### PR TITLE
Fix closing root block with }

### DIFF
--- a/chapter05/src/main/java/com/seaofnodes/simple/Parser.java
+++ b/chapter05/src/main/java/com/seaofnodes/simple/Parser.java
@@ -94,6 +94,7 @@ public class Parser {
             _scope.define(CTRL , new ProjNode(START, 0, CTRL ).peephole());
             _scope.define("arg", new ProjNode(START, 1, "arg").peephole());
             parseBlock();
+            if (!_lexer.isEOF()) throw error("Syntax error, unexpected " + _lexer.getAnyNextToken());
             return STOP;
         }
         finally {

--- a/chapter05/src/test/java/com/seaofnodes/simple/Chapter05Test.java
+++ b/chapter05/src/test/java/com/seaofnodes/simple/Chapter05Test.java
@@ -440,4 +440,15 @@ return c;
             assertEquals("Syntax error, expected }: ",e.getMessage());
         }
     }
+
+    @Test
+    public void testBad7() {
+        try {
+            new Parser("return 1;}").parse();
+            fail();
+        } catch( RuntimeException e ) {
+            assertEquals("Syntax error, unexpected }",e.getMessage());
+        }
+    }
+
 }


### PR DESCRIPTION
Currently the root block can be closed with `}` and garbage afterwards is skipped. This PR fixes this issue as in `return 1;}`.

This does not handle the case for code after the `return` statement as the grammar does not reflect this restriction.

If this is so good I would add the same checks to older chapters before merging.