### PR TITLE
Remove need for xScopes

### DIFF
--- a/chapter07/src/main/java/com/seaofnodes/simple/GraphVisualizer.java
+++ b/chapter07/src/main/java/com/seaofnodes/simple/GraphVisualizer.java
@@ -51,19 +51,19 @@ public class GraphVisualizer {
 
         // Just the Nodes first, in a cluster no edges
         nodes(sb, all);
+
+        List<Node> allScopes = all.stream().filter(n->n instanceof ScopeNode).toList();
         
         // Now the scopes, in a cluster no edges
-        scope(sb,parser._scope );
-        for( ScopeNode scope : parser._xScopes )
-            scope( sb, scope );
+        for( Node scope : allScopes )
+            scope( sb, (ScopeNode) scope );
 
         // Walk the Node edges
         nodeEdges(sb, all);
 
         // Walk the active Scope edges
-        scopeEdges( sb, parser._scope );
-        for( ScopeNode scope : parser._xScopes )
-            scopeEdges( sb, scope );
+        for( Node scope : allScopes )
+            scopeEdges( sb, (ScopeNode) scope );
         
         sb.append("}\n");
         return sb.toString();
@@ -236,10 +236,7 @@ public class GraphVisualizer {
      */
     private Collection<Node> findAll(Parser parser) {
         final HashMap<Integer, Node> all = new HashMap<>();
-        for( Node n : Parser.START._outputs )
-            walk(all, n);
-        for( Node n : parser._scope._inputs )
-            walk(all, n);
+        walk(all, Parser.START);
         return all.values();
     }
 


### PR DESCRIPTION
In case we wan't to remove the `xScopes` stack it can be partially recreated by searching for `ScopeNode`s in the list of all nodes. We loose the order, but that could be somewhat reconstructed by the number of variables each scope holds.

This might make debugging harder in case you want the scope stack.