### PR TITLE
Reset type cache to prevent alias blowup

### DIFF
--- a/chapter10/src/main/java/com/seaofnodes/simple/Parser.java
+++ b/chapter10/src/main/java/com/seaofnodes/simple/Parser.java
@@ -75,6 +75,7 @@ public class Parser {
     public Parser(String source, TypeInteger arg) {
         Node.reset();
         IterPeeps.reset();
+        Type.reset();
         OBJS.clear();
         _lexer = new Lexer(source);
         _scope = new ScopeNode();

--- a/chapter10/src/main/java/com/seaofnodes/simple/node/CastNode.java
+++ b/chapter10/src/main/java/com/seaofnodes/simple/node/CastNode.java
@@ -15,7 +15,12 @@ import java.util.BitSet;
 public class CastNode extends Node {
     private final Type _t;
     boolean _peep;
-    public CastNode(Type t, Node ctrl, Node in) { super(ctrl, in); _t = t; _peep=false; }
+    public CastNode(Type t, Node ctrl, Node in) {
+        super(ctrl, in);
+        _t = t;
+        _peep=false;
+        setType(compute());
+    }
 
     @Override public String label() { return "("+_t.str()+")"; }
 

--- a/chapter10/src/main/java/com/seaofnodes/simple/node/NotNode.java
+++ b/chapter10/src/main/java/com/seaofnodes/simple/node/NotNode.java
@@ -1,9 +1,7 @@
 package com.seaofnodes.simple.node;
 
 import com.seaofnodes.simple.Utils;
-import com.seaofnodes.simple.type.Type;
-import com.seaofnodes.simple.type.TypeInteger;
-import com.seaofnodes.simple.type.TypeMemPtr;
+import com.seaofnodes.simple.type.*;
 import java.util.BitSet;
 
 public class NotNode extends Node {
@@ -22,17 +20,21 @@ public class NotNode extends Node {
     @Override
     public Type compute() {
         Type t0 = in(1)._type;
-        if( t0 instanceof TypeInteger i0 )
+        switch( t0 ) {
+        case TypeInteger i0:
             return i0.isConstant() ? TypeInteger.constant(i0.value()==0 ? 1 : 0) : i0;
-        if( t0 instanceof TypeMemPtr p0 ) {
+        case TypeMemPtr p0:
             // top->top, bot->bot, null->1, void->0, ptr/NOT->0, ptr/nil->bot
             if( p0 == TypeMemPtr.TOP  ) return TypeInteger.TOP;
             if( p0 == TypeMemPtr.NULL ) return TypeInteger.constant(1);
             if( !p0._nil )              return TypeInteger.constant(0);
             return TypeInteger.BOT;
+        case Type t:
+            if( t0.getClass() != Type.class )
+                // Only doing NOT on ints and ptrs
+                throw Utils.TODO();
+            return t0==Type.TOP ? Type.TOP : Type.BOTTOM;
         }
-        // Only doing NOT on ints and ptrs
-        throw Utils.TODO();
     }
 
     @Override

--- a/chapter10/src/main/java/com/seaofnodes/simple/node/ProjNode.java
+++ b/chapter10/src/main/java/com/seaofnodes/simple/node/ProjNode.java
@@ -48,7 +48,7 @@ public class ProjNode extends Node {
         }
 
         // Flip a negating if-test, to remove the not
-        if( ctrl() instanceof IfNode iff && iff.pred() instanceof NotNode not )
+        if( ctrl() instanceof IfNode iff && iff.pred().addDep(this) instanceof NotNode not )
             return new ProjNode((MultiNode)new IfNode(iff.ctrl(),not.in(1)).peephole(),1-_idx,_idx==0 ? "False" : "True");
 
         return null;

--- a/chapter10/src/main/java/com/seaofnodes/simple/node/ScopeNode.java
+++ b/chapter10/src/main/java/com/seaofnodes/simple/node/ScopeNode.java
@@ -273,7 +273,7 @@ public class ScopeNode extends Node {
             if( Utils.find(_inputs, not.in(1)) != -1 ) {
                 Type tinit = not.in(1)._type.makeInit();
                 if( not.in(1)._type.isa(tinit) ) return null; // Already zero/null, no reason to upcast
-                return replace(not.in(1), new CastNode(tinit,null,not.in(1)).peephole());
+                return replace(not.in(1), new CastNode(tinit,null,not.in(1)));
             }
         }
         // Apr/9/2024: Attempted to replace X with Y if guarded by a test of

--- a/chapter10/src/main/java/com/seaofnodes/simple/type/Field.java
+++ b/chapter10/src/main/java/com/seaofnodes/simple/type/Field.java
@@ -79,4 +79,8 @@ public class Field extends Type {
     }
 
     @Override public String str() { return _fname; }
+
+    static void resetField() {
+        UNIQUE_ALIAS = 1;
+    }
 }

--- a/chapter10/src/main/java/com/seaofnodes/simple/type/Type.java
+++ b/chapter10/src/main/java/com/seaofnodes/simple/type/Type.java
@@ -185,11 +185,7 @@ public class Type {
     // This is used by error messages, and is a shorted print.
     public String str() { return STRS[_type]; }
 
-    private static HashMap<Type,Type> DEFAULT_INTERN;
     public static void reset() {
-        if (DEFAULT_INTERN == null) DEFAULT_INTERN = new HashMap<>(INTERN);
-        INTERN.clear();
-        INTERN.putAll(DEFAULT_INTERN);
         Field.resetField();
     }
 }

--- a/chapter10/src/main/java/com/seaofnodes/simple/type/Type.java
+++ b/chapter10/src/main/java/com/seaofnodes/simple/type/Type.java
@@ -184,4 +184,12 @@ public class Type {
 
     // This is used by error messages, and is a shorted print.
     public String str() { return STRS[_type]; }
+
+    private static HashMap<Type,Type> DEFAULT_INTERN;
+    public static void reset() {
+        if (DEFAULT_INTERN == null) DEFAULT_INTERN = new HashMap<>(INTERN);
+        INTERN.clear();
+        INTERN.putAll(DEFAULT_INTERN);
+        Field.resetField();
+    }
 }

--- a/chapter10/src/test/java/com/seaofnodes/simple/Chapter10Test.java
+++ b/chapter10/src/test/java/com/seaofnodes/simple/Chapter10Test.java
@@ -1,5 +1,6 @@
 package com.seaofnodes.simple;
 
+import com.seaofnodes.simple.node.Node;
 import com.seaofnodes.simple.node.StopNode;
 import com.seaofnodes.simple.type.*;
 import org.junit.Assert;
@@ -343,8 +344,20 @@ while(0) {}
             }
         }    }
 }
-    """);
+""");
         StopNode stop = parser.parse().iterate(true);
         assertEquals("Stop[ ]", stop.toString());
     }
+
+    @Test
+    public void testBug9() {
+        Parser parser = new Parser("""
+int v0=arg==0;
+while(v0) continue;
+return 0;
+""");
+        StopNode stop = parser.parse().iterate(true);
+        assertEquals("return 0;", stop.toString());
+    }
+
 }

--- a/chapter10/src/test/java/com/seaofnodes/simple/Chapter10Test.java
+++ b/chapter10/src/test/java/com/seaofnodes/simple/Chapter10Test.java
@@ -138,7 +138,7 @@ if( bar ) bar.a = 1;
 return bar;
 """);
         StopNode stop = parser.parse(false).iterate(true);
-        assertEquals("return Phi(Region18,null,new Bar);", stop.toString());
+        assertEquals("return Phi(Region14,null,new Bar);", stop.toString());
     }
 
     @Test
@@ -154,7 +154,7 @@ else bar.a = 1;
 return rez;
 """);
         StopNode stop = parser.parse(false).iterate(true);
-        assertEquals("return Phi(Region35,4,3);", stop.toString());
+        assertEquals("return Phi(Region31,4,3);", stop.toString());
     }
 
     @Test
@@ -204,7 +204,7 @@ return ret;
 """);
         StopNode stop = parser.parse(true).iterate(true);
         System.out.println(IRPrinter.prettyPrint(stop, 99, true));
-        assertEquals("return Phi(Loop12,new s0,Phi(Region33,new s0,Phi_ret));", stop.toString());
+        assertEquals("return Phi(Loop9,new s0,Phi(Region29,new s0,Phi_ret));", stop.toString());
     }
 
     @Test
@@ -223,7 +223,7 @@ return ret;
 """);
         StopNode stop = parser.parse(true).iterate(true);
         System.out.println(IRPrinter.prettyPrint(stop, 99, true));
-        assertEquals("return Phi(Loop15,new s0,Phi(Region34,new s0,Phi_ret));", stop.toString());
+        assertEquals("return Phi(Loop12,new s0,Phi(Region30,new s0,Phi_ret));", stop.toString());
     }
 
 
@@ -241,7 +241,7 @@ return ret;
 """);
         StopNode stop = parser.parse(true).iterate(true);
         System.out.println(IRPrinter.prettyPrint(stop, 99, true));
-        assertEquals("return Phi(Loop12,new s0,Phi(Region32,new s0,Phi_ret));", stop.toString());
+        assertEquals("return Phi(Loop9,new s0,Phi(Region28,new s0,Phi_ret));", stop.toString());
     }
 
     @Test


### PR DESCRIPTION
Currently the type cache and field aliases are not reset. For field aliases this is bad since the parser will add all aliases up to the maximum used. So new structs will use a lot of aliases from old cached structs from previous runs.