### PR TITLE
Fix NewNode initialization

### DIFF
--- a/chapter15/src/test/java/com/seaofnodes/simple/Chapter15Test.java
+++ b/chapter15/src/test/java/com/seaofnodes/simple/Chapter15Test.java
@@ -267,6 +267,23 @@ return rez;
             assertEquals(primes[i],(long)(Long)obj.fields()[i+1]);
     }
 
+    @Test
+    public void testNewNodeInit() {
+        Parser parser = new Parser(
+"""
+struct S {int i; flt f;}
+S s1 = new S;
+S s2 = new S;
+s2.i = 3;
+s2.f = 2.0;
+if (arg) s1 = new S;
+return s1.i + s1.f;
+""");
+        StopNode stop = parser.parse(false).iterate(false);
+        assertEquals("return ((flt).i+.f);", stop.toString());
+        assertEquals(0.0, Evaluator.evaluate(stop,  0));
+    }
+
 
     @Test
     public void testBad0() {

--- a/chapter15/src/test/java/com/seaofnodes/simple/SchedulerTest.java
+++ b/chapter15/src/test/java/com/seaofnodes/simple/SchedulerTest.java
@@ -48,7 +48,7 @@ return v0;
 """);
         StopNode stop = parser.parse(false).iterate(true);
         var eval = new Evaluator(stop);
-        assertObj(eval.evaluate(0, 10), "S", new Object[1]);
+        assertObj(eval.evaluate(0, 10), "S", 0L);
         assertObj(eval.evaluate(1, 10), "S", 1L);
     }
 


### PR DESCRIPTION
In ch15 the initialization of struct was moved from `StoreNode`s to the `NewNode`. Adjust the evaluator to initialize all fields correctly.