### PR TITLE
Set authenticated remote in workflow

### DIFF
--- a/.github/workflows/linearize.yml
+++ b/.github/workflows/linearize.yml
@@ -15,6 +15,7 @@ jobs:
           fetch-depth: 0 # Fetch the full history
       - name: Construct linear history and push to linear branch
         run: |
+          git remote set-url origin https://${GITHUB_ACTOR}:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
           git config user.name 'GitHub Action'
           git config user.email 'actions@github.com'
           .github/workflows/linearize.sh


### PR DESCRIPTION
Set the remote to an authenticated URL using the passed-in GitHub token.

It's been hard to test these changes, since they work in my fork, but haven't upstream. This is the pattern used in [Quine Relay](https://github.com/mame/quine-relay/blob/master/.github/workflows/main.yml)'s workflow, so hopefully it'll work.