### PR TITLE
Fix definition of 'isa' in TypeAnalysis.md

### DIFF
--- a/TypeAnalysis.md
+++ b/TypeAnalysis.md
@@ -84,8 +84,8 @@ and of course the *meet* is commutative and associative.
 The lattice *join* is defined from the *meet* and *dual* in 
 the normal way: `~(~x meet ~y)`
 
-Also *isa* is defined as `(x meet y)==y`, e.g.  `17.isa(Int)` expands to `(17
-meet Int)==Int` which becomes `(Int)==Int`.
+Also *isa* is defined as `(x meet y)==x`, e.g.  `17.isa(Int)` expands to `(17
+meet Int)==17` which becomes `(17)==17`.
 
 
 ### The Constant Propagation Algorithm


### PR DESCRIPTION
Maybe I got this all confused, but looking at the code in the tutorial, `Top` always loses to the other type in `meet` so `17 meet Int` should be `17`, not `Int`. An alternative definition can be `x.isa(y) <=> (x join y) == y`.

Again, this is just my limited understanding, and I would love to hear the explanation if I'm wrong.