### PR TITLE
close BufferedReader in getInput

### DIFF
--- a/chapter21/src/test/java/com/seaofnodes/simple/Simple.java
+++ b/chapter21/src/test/java/com/seaofnodes/simple/Simple.java
@@ -153,8 +153,9 @@ Options:
     }
 
     static String getInput() {
-        BufferedReader reader = new BufferedReader(new InputStreamReader(System.in));
-        return reader.lines().collect(Collectors.joining("\n"));
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(System.in))) {
+            return reader.lines().collect(Collectors.joining("\n"));
+        }
     }
 
     public static void main(String[] args) throws Exception {


### PR DESCRIPTION
The code around line 156 in chapter21/src/test/java/com/seaofnodes/simple/Simple.java looked like it might have an issue. The resource opened there can leak if getInput exits on an error path. this patch moves the allocation into try-with-resources so cleanup happens on every exit path.

Happy to revise the approach or close this if it doesn’t fit — you know the codebase far better than I do.