### PR TITLE
Move `addUse()` return statement to `keep()`

### DIFF
--- a/chapter02/src/main/java/com/seaofnodes/simple/node/Node.java
+++ b/chapter02/src/main/java/com/seaofnodes/simple/node/Node.java
@@ -153,7 +153,7 @@ public abstract class Node {
     }
 
     // Breaks the edge invariants, used temporarily
-    protected <N extends Node> N addUse(Node n) { _outputs.add(n); return (N)this; }
+    protected <N extends Node> void addUse(N n) { _outputs.add(n); }
 
     // Remove node 'use' from 'def's (i.e. our) output list, by compressing the list in-place.
     // Return true if the output list is empty afterward.

--- a/chapter03/src/main/java/com/seaofnodes/simple/node/Node.java
+++ b/chapter03/src/main/java/com/seaofnodes/simple/node/Node.java
@@ -177,7 +177,7 @@ public abstract class Node {
     }
 
     // Breaks the edge invariants, used temporarily
-    protected <N extends Node> N addUse(Node n) { _outputs.add(n); return (N)this; }
+    protected <N extends Node> void addUse(N n) { _outputs.add(n); }
 
     // Remove node 'use' from 'def's (i.e. our) output list, by compressing the list in-place.
     // Return true if the output list is empty afterward.

--- a/chapter04/src/main/java/com/seaofnodes/simple/node/Node.java
+++ b/chapter04/src/main/java/com/seaofnodes/simple/node/Node.java
@@ -168,7 +168,7 @@ public abstract class Node {
     }
 
     // Breaks the edge invariants, used temporarily
-    protected <N extends Node> N addUse(Node n) { _outputs.add(n); return (N)this; }
+    protected <N extends Node> void addUse(N n) { _outputs.add(n); }
 
     // Remove node 'use' from 'def's (i.e. our) output list, by compressing the list in-place.
     // Return true if the output list is empty afterward.
@@ -206,7 +206,7 @@ public abstract class Node {
 
     // Shortcuts to stop DCE mid-parse
     // Add bogus null use to keep node alive
-    public <N extends Node> N keep() { return addUse(null); }
+    public <N extends Node> N keep() { addUse(null); return (N)this; }
     // Remove bogus null.
     public <N extends Node> N unkeep() { delUse(null); return (N)this; }
     // ------------------------------------------------------------------------

--- a/chapter05/src/main/java/com/seaofnodes/simple/node/Node.java
+++ b/chapter05/src/main/java/com/seaofnodes/simple/node/Node.java
@@ -168,7 +168,7 @@ public abstract class Node {
     }
 
     // Breaks the edge invariants, used temporarily
-    protected <N extends Node> N addUse(Node n) { _outputs.add(n); return (N)this; }
+    protected <N extends Node> void addUse(N n) { _outputs.add(n); }
 
     // Remove node 'use' from 'def's (i.e. our) output list, by compressing the list in-place.
     // Return true if the output list is empty afterward.
@@ -206,7 +206,7 @@ public abstract class Node {
 
     // Shortcuts to stop DCE mid-parse
     // Add bogus null use to keep node alive
-    public <N extends Node> N keep() { return addUse(null); }
+    public <N extends Node> N keep() { addUse(null); return (N)this; }
     // Remove bogus null.
     public <N extends Node> N unkeep() { delUse(null); return (N)this; }
     // ------------------------------------------------------------------------

--- a/chapter06/src/main/java/com/seaofnodes/simple/node/Node.java
+++ b/chapter06/src/main/java/com/seaofnodes/simple/node/Node.java
@@ -189,7 +189,7 @@ public abstract class Node {
     }
 
     // Breaks the edge invariants, used temporarily
-    protected <N extends Node> N addUse(Node n) { _outputs.add(n); return (N)this; }
+    protected <N extends Node> void addUse(N n) { _outputs.add(n); }
 
     // Remove node 'use' from 'def's (i.e. our) output list, by compressing the list in-place.
     // Return true if the output list is empty afterward.
@@ -227,7 +227,7 @@ public abstract class Node {
 
     // Shortcuts to stop DCE mid-parse
     // Add bogus null use to keep node alive
-    public <N extends Node> N keep() { return addUse(null); }
+    public <N extends Node> N keep() { addUse(null); return (N)this; }
     // Remove bogus null.
     public <N extends Node> N unkeep() { delUse(null); return (N)this; }
     // ------------------------------------------------------------------------

--- a/chapter07/src/main/java/com/seaofnodes/simple/node/Node.java
+++ b/chapter07/src/main/java/com/seaofnodes/simple/node/Node.java
@@ -222,7 +222,7 @@ public abstract class Node {
     }
 
     // Breaks the edge invariants, used temporarily
-    protected <N extends Node> N addUse(Node n) { _outputs.add(n); return (N)this; }
+    protected <N extends Node> void addUse(N n) { _outputs.add(n); }
 
     // Remove node 'use' from 'def's (i.e. our) output list, by compressing the list in-place.
     // Return true if the output list is empty afterward.
@@ -260,7 +260,7 @@ public abstract class Node {
 
     // Shortcuts to stop DCE mid-parse
     // Add bogus null use to keep node alive
-    public <N extends Node> N keep() { return addUse(null); }
+    public <N extends Node> N keep() { addUse(null); return (N)this; }
     // Remove bogus null.
     public <N extends Node> N unkeep() { delUse(null); return (N)this; }
 

--- a/chapter08/src/main/java/com/seaofnodes/simple/node/Node.java
+++ b/chapter08/src/main/java/com/seaofnodes/simple/node/Node.java
@@ -224,7 +224,7 @@ public abstract class Node {
     }
 
     // Breaks the edge invariants, used temporarily
-    protected <N extends Node> N addUse(Node n) { _outputs.add(n); return (N)this; }
+    protected <N extends Node> void addUse(N n) { _outputs.add(n); }
 
     // Remove node 'use' from 'def's (i.e. our) output list, by compressing the list in-place.
     // Return true if the output list is empty afterward.
@@ -262,7 +262,7 @@ public abstract class Node {
 
     // Shortcuts to stop DCE mid-parse
     // Add bogus null use to keep node alive
-    public <N extends Node> N keep() { return addUse(null); }
+    public <N extends Node> N keep() { addUse(null); return (N)this; }
     // Remove bogus null.
     public <N extends Node> N unkeep() { delUse(null); return (N)this; }
 

--- a/chapter09/src/main/java/com/seaofnodes/simple/node/Node.java
+++ b/chapter09/src/main/java/com/seaofnodes/simple/node/Node.java
@@ -234,7 +234,7 @@ public abstract class Node {
     }
 
     // Breaks the edge invariants, used temporarily
-    protected <N extends Node> N addUse(Node n) { _outputs.add(n); return (N)this; }
+    protected <N extends Node> void addUse(N n) { _outputs.add(n); }
 
     // Remove node 'use' from 'def's (i.e. our) output list, by compressing the list in-place.
     // Return true if the output list is empty afterward.
@@ -281,7 +281,7 @@ public abstract class Node {
 
     // Shortcuts to stop DCE mid-parse
     // Add bogus null use to keep node alive
-    public <N extends Node> N keep() { return addUse(null); }
+    public <N extends Node> N keep() { addUse(null); return (N)this; }
     // Remove bogus null.
     public <N extends Node> N unkeep() { delUse(null); return (N)this; }
 

--- a/chapter10/src/main/java/com/seaofnodes/simple/node/Node.java
+++ b/chapter10/src/main/java/com/seaofnodes/simple/node/Node.java
@@ -207,7 +207,7 @@ public abstract class Node {
     }
 
     // Breaks the edge invariants, used temporarily
-    protected <N extends Node> N addUse(Node n) { _outputs.add(n); return (N)this; }
+    protected <N extends Node> void addUse(N n) { _outputs.add(n); }
 
     // Remove node 'use' from 'def's (i.e. our) output list, by compressing the list in-place.
     // Return true if the output list is empty afterward.
@@ -254,12 +254,9 @@ public abstract class Node {
 
     // Shortcuts to stop DCE mid-parse
     // Add bogus null use to keep node alive
-    public <N extends Node> N keep() { return addUse(null); }
+    public <N extends Node> N keep() { addUse(null); return (N)this; }
     // Remove bogus null.
-    public <N extends Node> N unkeep() {
-        delUse(null);
-        return (N)this;
-    }
+    public <N extends Node> N unkeep() { delUse(null); return (N)this; }
     // Test "keep" status
     public boolean iskeep() { return Utils.find(_outputs,null) != -1; }
 

--- a/chapter11/src/main/java/com/seaofnodes/simple/node/Node.java
+++ b/chapter11/src/main/java/com/seaofnodes/simple/node/Node.java
@@ -207,7 +207,7 @@ public abstract class Node implements OutNode {
     }
 
     // Breaks the edge invariants, used temporarily
-    protected <N extends Node> N addUse(Node n) { _outputs.add(n); return (N)this; }
+    protected <N extends Node> void addUse(N n) { _outputs.add(n); }
 
     // Remove node 'use' from 'def's (i.e. our) output list, by compressing the list in-place.
     // Return true if the output list is empty afterward.
@@ -254,12 +254,9 @@ public abstract class Node implements OutNode {
 
     // Shortcuts to stop DCE mid-parse
     // Add bogus null use to keep node alive
-    public <N extends Node> N keep() { return addUse(null); }
+    public <N extends Node> N keep() { addUse(null); return (N)this; }
     // Remove bogus null.
-    public <N extends Node> N unkeep() {
-        delUse(null);
-        return (N)this;
-    }
+    public <N extends Node> N unkeep() { delUse(null); return (N)this; }
     // Test "keep" status
     public boolean iskeep() { return Utils.find(_outputs,null) != -1; }
 

--- a/chapter12/src/main/java/com/seaofnodes/simple/node/Node.java
+++ b/chapter12/src/main/java/com/seaofnodes/simple/node/Node.java
@@ -207,7 +207,7 @@ public abstract class Node implements OutNode {
     }
 
     // Breaks the edge invariants, used temporarily
-    protected <N extends Node> N addUse(Node n) { _outputs.add(n); return (N)this; }
+    protected <N extends Node> void addUse(N n) { _outputs.add(n); }
 
     // Remove node 'use' from 'def's (i.e. our) output list, by compressing the list in-place.
     // Return true if the output list is empty afterward.
@@ -255,12 +255,9 @@ public abstract class Node implements OutNode {
 
     // Shortcuts to stop DCE mid-parse
     // Add bogus null use to keep node alive
-    public <N extends Node> N keep() { return addUse(null); }
+    public <N extends Node> N keep() { addUse(null); return (N)this; }
     // Remove bogus null.
-    public <N extends Node> N unkeep() {
-        delUse(null);
-        return (N)this;
-    }
+    public <N extends Node> N unkeep() { delUse(null); return (N)this; }
     // Test "keep" status
     public boolean iskeep() { return Utils.find(_outputs,null) != -1; }
 

--- a/chapter13/src/main/java/com/seaofnodes/simple/node/Node.java
+++ b/chapter13/src/main/java/com/seaofnodes/simple/node/Node.java
@@ -207,7 +207,7 @@ public abstract class Node implements OutNode {
     }
 
     // Breaks the edge invariants, used temporarily
-    protected <N extends Node> N addUse(Node n) { _outputs.add(n); return (N)this; }
+    protected <N extends Node> void addUse(N n) { _outputs.add(n); }
 
     // Remove node 'use' from 'def's (i.e. our) output list, by compressing the list in-place.
     // Return true if the output list is empty afterward.
@@ -255,12 +255,9 @@ public abstract class Node implements OutNode {
 
     // Shortcuts to stop DCE mid-parse
     // Add bogus null use to keep node alive
-    public <N extends Node> N keep() { return addUse(null); }
+    public <N extends Node> N keep() { addUse(null); return (N)this; }
     // Remove bogus null.
-    public <N extends Node> N unkeep() {
-        delUse(null);
-        return (N)this;
-    }
+    public <N extends Node> N unkeep() { delUse(null); return (N)this; }
     // Test "keep" status
     public boolean iskeep() { return Utils.find(_outputs,null) != -1; }
 

--- a/chapter14/src/main/java/com/seaofnodes/simple/node/Node.java
+++ b/chapter14/src/main/java/com/seaofnodes/simple/node/Node.java
@@ -205,7 +205,7 @@ public abstract class Node implements OutNode {
     }
 
     // Breaks the edge invariants, used temporarily
-    protected <N extends Node> N addUse(Node n) { _outputs.add(n); return (N)this; }
+    protected <N extends Node> void addUse(N n) { _outputs.add(n); }
 
     // Remove node 'use' from 'def's (i.e. our) output list, by compressing the list in-place.
     // Return true if the output list is empty afterward.
@@ -253,12 +253,9 @@ public abstract class Node implements OutNode {
 
     // Shortcuts to stop DCE mid-parse
     // Add bogus null use to keep node alive
-    public <N extends Node> N keep() { return addUse(null); }
+    public <N extends Node> N keep() { addUse(null); return (N)this; }
     // Remove bogus null.
-    public <N extends Node> N unkeep() {
-        delUse(null);
-        return (N)this;
-    }
+    public <N extends Node> N unkeep() { delUse(null); return (N)this; }
     // Test "keep" status
     public boolean iskeep() { return Utils.find(_outputs,null) != -1; }
 

--- a/chapter15/src/main/java/com/seaofnodes/simple/node/Node.java
+++ b/chapter15/src/main/java/com/seaofnodes/simple/node/Node.java
@@ -204,7 +204,7 @@ public abstract class Node implements OutNode {
     }
 
     // Breaks the edge invariants, used temporarily
-    protected <N extends Node> N addUse(Node n) { _outputs.add(n); return (N)this; }
+    protected <N extends Node> void addUse(N n) { _outputs.add(n); }
 
     // Remove node 'use' from 'def's (i.e. our) output list, by compressing the list in-place.
     // Return true if the output list is empty afterward.
@@ -252,12 +252,9 @@ public abstract class Node implements OutNode {
 
     // Shortcuts to stop DCE mid-parse
     // Add bogus null use to keep node alive
-    public <N extends Node> N keep() { return addUse(null); }
+    public <N extends Node> N keep() { addUse(null); return (N)this; }
     // Remove bogus null.
-    public <N extends Node> N unkeep() {
-        delUse(null);
-        return (N)this;
-    }
+    public <N extends Node> N unkeep() { delUse(null); return (N)this; }
     // Test "keep" status
     public boolean iskeep() { return Utils.find(_outputs,null) != -1; }
 

--- a/chapter16/src/main/java/com/seaofnodes/simple/node/Node.java
+++ b/chapter16/src/main/java/com/seaofnodes/simple/node/Node.java
@@ -211,7 +211,7 @@ public abstract class Node implements OutNode {
     }
 
     // Breaks the edge invariants, used temporarily
-    protected <N extends Node> N addUse(Node n) { _outputs.add(n); return (N)this; }
+    protected <N extends Node> void addUse(N n) { _outputs.add(n); }
 
     // Remove node 'use' from 'def's (i.e. our) output list, by compressing the list in-place.
     // Return true if the output list is empty afterward.
@@ -259,12 +259,9 @@ public abstract class Node implements OutNode {
 
     // Shortcuts to stop DCE mid-parse
     // Add bogus null use to keep node alive
-    public <N extends Node> N keep() { return addUse(null); }
+    public <N extends Node> N keep() { addUse(null); return (N)this; }
     // Remove bogus null.
-    public <N extends Node> N unkeep() {
-        delUse(null);
-        return (N)this;
-    }
+    public <N extends Node> N unkeep() { delUse(null); return (N)this; }
     // Test "keep" status
     public boolean iskeep() { return _outputs.find(null) != -1; }
 

--- a/chapter17/src/main/java/com/seaofnodes/simple/node/Node.java
+++ b/chapter17/src/main/java/com/seaofnodes/simple/node/Node.java
@@ -211,7 +211,7 @@ public abstract class Node implements OutNode {
     }
 
     // Breaks the edge invariants, used temporarily
-    protected <N extends Node> N addUse(Node n) { _outputs.add(n); return (N)this; }
+    protected <N extends Node> void addUse(N n) { _outputs.add(n); }
 
     // Remove node 'use' from 'def's (i.e. our) output list, by compressing the list in-place.
     // Return true if the output list is empty afterward.
@@ -259,12 +259,9 @@ public abstract class Node implements OutNode {
 
     // Shortcuts to stop DCE mid-parse
     // Add bogus null use to keep node alive
-    public <N extends Node> N keep() { return addUse(null); }
+    public <N extends Node> N keep() { addUse(null); return (N)this; }
     // Remove bogus null.
-    public <N extends Node> N unkeep() {
-        delUse(null);
-        return (N)this;
-    }
+    public <N extends Node> N unkeep() { delUse(null); return (N)this; }
     // Test "keep" status
     public boolean iskeep() { return _outputs.find(null) != -1; }
     public void unkill() {

--- a/chapter18/src/main/java/com/seaofnodes/simple/node/Node.java
+++ b/chapter18/src/main/java/com/seaofnodes/simple/node/Node.java
@@ -212,7 +212,7 @@ public abstract class Node {
     }
 
     // Breaks the edge invariants, used temporarily
-    protected <N extends Node> N addUse(Node n) { _outputs.add(n); return (N)this; }
+    protected <N extends Node> void addUse(N n) { _outputs.add(n); }
 
     // Remove node 'use' from 'def's (i.e. our) output list, by compressing the list in-place.
     // Return true if the output list is empty afterward.
@@ -260,12 +260,9 @@ public abstract class Node {
 
     // Shortcuts to stop DCE mid-parse
     // Add bogus null use to keep node alive
-    public <N extends Node> N keep() { return addUse(null); }
+    public <N extends Node> N keep() { addUse(null); return (N)this; }
     // Remove bogus null.
-    public <N extends Node> N unkeep() {
-        delUse(null);
-        return (N)this;
-    }
+    public <N extends Node> N unkeep() { delUse(null); return (N)this; }
     // Test "keep" status
     public boolean iskeep() { return _outputs.find(null) != -1; }
     public void unkill() {

--- a/chapter19/src/main/java/com/seaofnodes/simple/node/Node.java
+++ b/chapter19/src/main/java/com/seaofnodes/simple/node/Node.java
@@ -221,7 +221,7 @@ public abstract class Node {
     }
 
     // Breaks the edge invariants, used temporarily
-    protected <N extends Node> N addUse(Node n) { _outputs.add(n); return (N)this; }
+    protected <N extends Node> void addUse(N n) { _outputs.add(n); }
 
     // Remove node 'use' from 'def's (i.e. our) output list, by compressing the list in-place.
     // Return true if the output list is empty afterward.
@@ -267,12 +267,9 @@ public abstract class Node {
 
     // Shortcuts to stop DCE mid-parse
     // Add bogus null use to keep node alive
-    public <N extends Node> N keep() { return addUse(null); }
+    public <N extends Node> N keep() { addUse(null); return (N)this; }
     // Remove bogus null.
-    public <N extends Node> N unkeep() {
-        delUse(null);
-        return (N)this;
-    }
+    public <N extends Node> N unkeep() { delUse(null); return (N)this; }
     // Test "keep" status
     public boolean iskeep() { return _outputs.find(null) != -1; }
     public void unkill() {

--- a/chapter20/src/main/java/com/seaofnodes/simple/node/Node.java
+++ b/chapter20/src/main/java/com/seaofnodes/simple/node/Node.java
@@ -226,7 +226,7 @@ public abstract class Node {
     }
 
     // Breaks the edge invariants, used temporarily
-    protected <N extends Node> N addUse(Node n) { _outputs.add(n); return (N)this; }
+    protected <N extends Node> void addUse(N n) { _outputs.add(n); }
 
     // Remove node 'use' from 'def's (i.e. our) output list, by compressing the list in-place.
     // Return true if the output list is empty afterward.
@@ -272,12 +272,9 @@ public abstract class Node {
 
     // Shortcuts to stop DCE mid-parse
     // Add bogus null use to keep node alive
-    public <N extends Node> N keep() { return addUse(null); }
+    public <N extends Node> N keep() { addUse(null); return (N)this; }
     // Remove bogus null.
-    public <N extends Node> N unkeep() {
-        delUse(null);
-        return (N)this;
-    }
+    public <N extends Node> N unkeep() { delUse(null); return (N)this; }
     // Test "keep" status
     public boolean iskeep() { return _outputs.find(null) != -1; }
     public void unkill() {

--- a/chapter21/src/main/java/com/seaofnodes/simple/node/Node.java
+++ b/chapter21/src/main/java/com/seaofnodes/simple/node/Node.java
@@ -226,8 +226,7 @@ public abstract class Node implements Cloneable {
     }
 
     // Breaks the edge invariants, used temporarily
-    @SuppressWarnings("unchecked")
-    protected <N extends Node> N addUse(Node n) { _outputs.add(n); return (N)this; }
+    protected <N extends Node> void addUse(N n) { _outputs.add(n); }
 
     // Remove node 'use' from 'def's (i.e. our) output list, by compressing the list in-place.
     // Return true if the output list is empty afterward.
@@ -282,13 +281,11 @@ public abstract class Node implements Cloneable {
 
     // Shortcuts to stop DCE mid-parse
     // Add bogus null use to keep node alive
-    public <N extends Node> N keep() { return addUse(null); }
+    @SuppressWarnings("unchecked")
+    public <N extends Node> N keep() { addUse(null); return (N)this; }
     // Remove bogus null.
     @SuppressWarnings("unchecked")
-    public <N extends Node> N unkeep() {
-        delUse(null);
-        return (N)this;
-    }
+    public <N extends Node> N unkeep() { delUse(null); return (N)this; }
     // Test "keep" status
     public boolean iskeep() { return _outputs.find(null) != -1; }
     public void unkill() {

--- a/chapter22/src/main/java/com/seaofnodes/simple/node/Node.java
+++ b/chapter22/src/main/java/com/seaofnodes/simple/node/Node.java
@@ -226,8 +226,7 @@ public abstract class Node implements Cloneable {
     }
 
     // Breaks the edge invariants, used temporarily
-    @SuppressWarnings("unchecked")
-    protected <N extends Node> N addUse(Node n) { _outputs.add(n); return (N)this; }
+    protected <N extends Node> void addUse(N n) { _outputs.add(n); }
 
     // Remove node 'use' from 'def's (i.e. our) output list, by compressing the list in-place.
     // Return true if the output list is empty afterward.
@@ -282,13 +281,11 @@ public abstract class Node implements Cloneable {
 
     // Shortcuts to stop DCE mid-parse
     // Add bogus null use to keep node alive
-    public <N extends Node> N keep() { return addUse(null); }
+    @SuppressWarnings("unchecked")
+    public <N extends Node> N keep() { addUse(null); return (N)this; }
     // Remove bogus null.
     @SuppressWarnings("unchecked")
-    public <N extends Node> N unkeep() {
-        delUse(null);
-        return (N)this;
-    }
+    public <N extends Node> N unkeep() { delUse(null); return (N)this; }
     // Test "keep" status
     public boolean iskeep() { return _outputs.find(null) != -1; }
     public void unkill() {

--- a/chapter23/src/main/java/com/seaofnodes/simple/node/Node.java
+++ b/chapter23/src/main/java/com/seaofnodes/simple/node/Node.java
@@ -228,8 +228,7 @@ public abstract class Node implements Cloneable {
     }
 
     // Breaks the edge invariants, used temporarily
-    @SuppressWarnings("unchecked")
-    protected <N extends Node> N addUse(Node n) { _outputs.add(n); return (N)this; }
+    protected <N extends Node> void addUse(N n) { _outputs.add(n); }
 
     // Remove node 'use' from 'def's (i.e. our) output list, by compressing the list in-place.
     // Return true if the output list is empty afterward.
@@ -284,13 +283,11 @@ public abstract class Node implements Cloneable {
 
     // Shortcuts to stop DCE mid-parse
     // Add bogus null use to keep node alive
-    public <N extends Node> N keep() { return addUse(null); }
+    @SuppressWarnings("unchecked")
+    public <N extends Node> N keep() { addUse(null); return (N)this; }
     // Remove bogus null.
     @SuppressWarnings("unchecked")
-    public <N extends Node> N unkeep() {
-        delUse(null);
-        return (N)this;
-    }
+    public <N extends Node> N unkeep() { delUse(null); return (N)this; }
     // Test "keep" status
     public boolean iskeep() { return _outputs.find(null) != -1; }
     public void unkill() {

--- a/chapter24/src/main/java/com/seaofnodes/simple/node/Node.java
+++ b/chapter24/src/main/java/com/seaofnodes/simple/node/Node.java
@@ -229,8 +229,7 @@ public abstract class Node implements Cloneable {
     }
 
     // Breaks the edge invariants, used temporarily
-    @SuppressWarnings("unchecked")
-    protected <N extends Node> N addUse(Node n) { _outputs.add(n); return (N)this; }
+    protected <N extends Node> void addUse(N n) { _outputs.add(n); }
 
     // Remove node 'use' from 'def's (i.e. our) output list, by compressing the list in-place.
     // Return true if the output list is empty afterward.
@@ -285,13 +284,11 @@ public abstract class Node implements Cloneable {
 
     // Shortcuts to stop DCE mid-parse
     // Add bogus null use to keep node alive
-    public <N extends Node> N keep() { return addUse(null); }
+    @SuppressWarnings("unchecked")
+    public <N extends Node> N keep() { addUse(null); return (N)this; }
     // Remove bogus null.
     @SuppressWarnings("unchecked")
-    public <N extends Node> N unkeep() {
-        delUse(null);
-        return (N)this;
-    }
+    public <N extends Node> N unkeep() { delUse(null); return (N)this; }
     // Test "keep" status
     public boolean iskeep() { return _outputs.find(null) != -1; }
     public void unkill() {


### PR DESCRIPTION
Move `return (N)this;` and the associated `@SuppressWarnings("unchecked")` to its only user `keep()`.

Align `keep()` and `unkeep()` to reflect their mirroring nature.