### PR TITLE
Backport renaming of `Type::_print()` in Chapter13 to earlier chapters

### DIFF
--- a/chapter02/src/main/java/com/seaofnodes/simple/node/ConstantNode.java
+++ b/chapter02/src/main/java/com/seaofnodes/simple/node/ConstantNode.java
@@ -30,7 +30,7 @@ public class ConstantNode extends Node {
 
     @Override
     StringBuilder _print1(StringBuilder sb) {
-        return _con._print(sb);
+        return _con.print(sb);
     }
 
     @Override

--- a/chapter02/src/main/java/com/seaofnodes/simple/type/Type.java
+++ b/chapter02/src/main/java/com/seaofnodes/simple/type/Type.java
@@ -36,5 +36,5 @@ public class Type {
 
     public boolean isConstant() { return _type == TTOP; }
 
-    public StringBuilder _print(StringBuilder sb) {return is_simple() ? sb.append(STRS[_type]) : sb;}
+    public StringBuilder print(StringBuilder sb) {return is_simple() ? sb.append(STRS[_type]) : sb;}
 }

--- a/chapter02/src/main/java/com/seaofnodes/simple/type/TypeInteger.java
+++ b/chapter02/src/main/java/com/seaofnodes/simple/type/TypeInteger.java
@@ -21,11 +21,11 @@ public class TypeInteger extends Type {
 
     @Override
     public String toString() {
-      return _print(new StringBuilder()).toString();
+      return print(new StringBuilder()).toString();
     }
 
     @Override
-    public StringBuilder _print(StringBuilder sb) { return sb.append(_con); }
+    public StringBuilder print(StringBuilder sb) { return sb.append(_con); }
 
     @Override
     public boolean isConstant() { return true; }

--- a/chapter03/src/main/java/com/seaofnodes/simple/node/ConstantNode.java
+++ b/chapter03/src/main/java/com/seaofnodes/simple/node/ConstantNode.java
@@ -30,7 +30,7 @@ public class ConstantNode extends Node {
 
     @Override
     StringBuilder _print1(StringBuilder sb) {
-        return _con._print(sb);
+        return _con.print(sb);
     }
 
     @Override

--- a/chapter03/src/main/java/com/seaofnodes/simple/type/Type.java
+++ b/chapter03/src/main/java/com/seaofnodes/simple/type/Type.java
@@ -36,5 +36,5 @@ public class Type {
 
     public boolean isConstant() { return _type == TTOP; }
 
-    public StringBuilder _print(StringBuilder sb) {return is_simple() ? sb.append(STRS[_type]) : sb;}
+    public StringBuilder print(StringBuilder sb) {return is_simple() ? sb.append(STRS[_type]) : sb;}
 }

--- a/chapter03/src/main/java/com/seaofnodes/simple/type/TypeInteger.java
+++ b/chapter03/src/main/java/com/seaofnodes/simple/type/TypeInteger.java
@@ -21,11 +21,11 @@ public class TypeInteger extends Type {
 
     @Override
     public String toString() {
-      return _print(new StringBuilder()).toString();
+      return print(new StringBuilder()).toString();
     }
 
     @Override
-    public StringBuilder _print(StringBuilder sb) { return sb.append(_con); }
+    public StringBuilder print(StringBuilder sb) { return sb.append(_con); }
 
     @Override
     public boolean isConstant() { return true; }

--- a/chapter04/src/main/java/com/seaofnodes/simple/node/ConstantNode.java
+++ b/chapter04/src/main/java/com/seaofnodes/simple/node/ConstantNode.java
@@ -30,7 +30,7 @@ public class ConstantNode extends Node {
 
     @Override
     StringBuilder _print1(StringBuilder sb) {
-        return _con._print(sb);
+        return _con.print(sb);
     }
 
     @Override

--- a/chapter04/src/main/java/com/seaofnodes/simple/type/Type.java
+++ b/chapter04/src/main/java/com/seaofnodes/simple/type/Type.java
@@ -41,12 +41,12 @@ public class Type {
 
     public boolean isConstant() { return _type == TTOP; }
 
-    public StringBuilder _print(StringBuilder sb) {return is_simple() ? sb.append(STRS[_type]) : sb;}
+    public StringBuilder print(StringBuilder sb) {return is_simple() ? sb.append(STRS[_type]) : sb;}
 
     public Type meet(Type other) { return Type.BOTTOM; }
 
     @Override
     public final String toString() {
-        return _print(new StringBuilder()).toString();
+        return print(new StringBuilder()).toString();
     }
 }

--- a/chapter04/src/main/java/com/seaofnodes/simple/type/TypeInteger.java
+++ b/chapter04/src/main/java/com/seaofnodes/simple/type/TypeInteger.java
@@ -29,7 +29,7 @@ public class TypeInteger extends Type {
     public boolean isBot() { return !_is_con && _con==1; }
 
     @Override
-    public StringBuilder _print(StringBuilder sb) {
+    public StringBuilder print(StringBuilder sb) {
         if (isTop()) return sb.append("IntTop");
         if (isBot()) return sb.append("IntBot");
         return sb.append(_con);

--- a/chapter04/src/main/java/com/seaofnodes/simple/type/TypeTuple.java
+++ b/chapter04/src/main/java/com/seaofnodes/simple/type/TypeTuple.java
@@ -15,10 +15,10 @@ public class TypeTuple extends Type {
     }
 
     @Override
-    public StringBuilder _print(StringBuilder sb) {
+    public StringBuilder print(StringBuilder sb) {
         sb.append("[ ");
         for( Type t : _types )
-            t._print(sb).append(",");
+            t.print(sb).append(",");
         sb.setLength(sb.length()-1);
         sb.append("]");
         return sb;

--- a/chapter05/src/main/java/com/seaofnodes/simple/node/ConstantNode.java
+++ b/chapter05/src/main/java/com/seaofnodes/simple/node/ConstantNode.java
@@ -30,7 +30,7 @@ public class ConstantNode extends Node {
 
     @Override
     StringBuilder _print1(StringBuilder sb) {
-        return _con._print(sb);
+        return _con.print(sb);
     }
 
     @Override

--- a/chapter05/src/main/java/com/seaofnodes/simple/type/Type.java
+++ b/chapter05/src/main/java/com/seaofnodes/simple/type/Type.java
@@ -41,12 +41,12 @@ public class Type {
 
     public boolean isConstant() { return _type == TTOP; }
 
-    public StringBuilder _print(StringBuilder sb) {return is_simple() ? sb.append(STRS[_type]) : sb;}
+    public StringBuilder print(StringBuilder sb) {return is_simple() ? sb.append(STRS[_type]) : sb;}
 
     public Type meet(Type other) { return BOTTOM; }
 
     @Override
     public final String toString() {
-        return _print(new StringBuilder()).toString();
+        return print(new StringBuilder()).toString();
     }
 }

--- a/chapter05/src/main/java/com/seaofnodes/simple/type/TypeInteger.java
+++ b/chapter05/src/main/java/com/seaofnodes/simple/type/TypeInteger.java
@@ -29,7 +29,7 @@ public class TypeInteger extends Type {
     public boolean isBot() { return !_is_con && _con==1; }
 
     @Override
-    public StringBuilder _print(StringBuilder sb) {
+    public StringBuilder print(StringBuilder sb) {
         if (isTop()) return sb.append("IntTop");
         if (isBot()) return sb.append("IntBot");
         return sb.append(_con);

--- a/chapter05/src/main/java/com/seaofnodes/simple/type/TypeTuple.java
+++ b/chapter05/src/main/java/com/seaofnodes/simple/type/TypeTuple.java
@@ -15,10 +15,10 @@ public class TypeTuple extends Type {
     }
 
     @Override
-    public StringBuilder _print(StringBuilder sb) {
+    public StringBuilder print(StringBuilder sb) {
         sb.append("[");
         for( Type t : _types )
-            t._print(sb).append(",");
+            t.print(sb).append(",");
         sb.setLength(sb.length()-1);
         sb.append("]");
         return sb;

--- a/chapter06/src/main/java/com/seaofnodes/simple/node/ConstantNode.java
+++ b/chapter06/src/main/java/com/seaofnodes/simple/node/ConstantNode.java
@@ -30,7 +30,7 @@ public class ConstantNode extends Node {
 
     @Override
     StringBuilder _print1(StringBuilder sb) {
-        return _con._print(sb);
+        return _con.print(sb);
     }
 
     @Override

--- a/chapter06/src/main/java/com/seaofnodes/simple/type/Type.java
+++ b/chapter06/src/main/java/com/seaofnodes/simple/type/Type.java
@@ -43,7 +43,7 @@ public class Type {
 
     public boolean isConstant() { return _type == TTOP || _type == TXCTRL; }
 
-    public StringBuilder _print(StringBuilder sb) {return is_simple() ? sb.append(STRS[_type]) : sb;}
+    public StringBuilder print(StringBuilder sb) {return is_simple() ? sb.append(STRS[_type]) : sb;}
 
     public final Type meet(Type t) {
         // Shortcut for the self case
@@ -72,6 +72,6 @@ public class Type {
 
     @Override
     public final String toString() {
-        return _print(new StringBuilder()).toString();
+        return print(new StringBuilder()).toString();
     }
 }

--- a/chapter06/src/main/java/com/seaofnodes/simple/type/TypeInteger.java
+++ b/chapter06/src/main/java/com/seaofnodes/simple/type/TypeInteger.java
@@ -29,7 +29,7 @@ public class TypeInteger extends Type {
     public boolean isBot() { return !_is_con && _con==1; }
 
     @Override
-    public StringBuilder _print(StringBuilder sb) {
+    public StringBuilder print(StringBuilder sb) {
         if (isTop()) return sb.append("IntTop");
         if (isBot()) return sb.append("IntBot");
         return sb.append(_con);

--- a/chapter06/src/main/java/com/seaofnodes/simple/type/TypeTuple.java
+++ b/chapter06/src/main/java/com/seaofnodes/simple/type/TypeTuple.java
@@ -15,10 +15,10 @@ public class TypeTuple extends Type {
     }
 
     @Override
-    public StringBuilder _print(StringBuilder sb) {
+    public StringBuilder print(StringBuilder sb) {
         sb.append("[");
         for( Type t : _types )
-            t._print(sb).append(",");
+            t.print(sb).append(",");
         sb.setLength(sb.length()-1);
         sb.append("]");
         return sb;

--- a/chapter07/src/main/java/com/seaofnodes/simple/node/ConstantNode.java
+++ b/chapter07/src/main/java/com/seaofnodes/simple/node/ConstantNode.java
@@ -32,7 +32,7 @@ public class ConstantNode extends Node {
 
     @Override
     StringBuilder _print1(StringBuilder sb, BitSet visited) {
-        return _con._print(sb);
+        return _con.print(sb);
     }
 
     @Override public boolean isMultiTail() { return true; }

--- a/chapter07/src/main/java/com/seaofnodes/simple/node/Node.java
+++ b/chapter07/src/main/java/com/seaofnodes/simple/node/Node.java
@@ -134,7 +134,7 @@ public abstract class Node {
         for( int i = _outputs.size(); i<lim; i++ )
             sb.append("     ");
         sb.append(" ]]  ");
-        if( _type!= null ) _type._print(sb);
+        if( _type!= null ) _type.print(sb);
         sb.append("\n");
     }
 

--- a/chapter07/src/main/java/com/seaofnodes/simple/type/Type.java
+++ b/chapter07/src/main/java/com/seaofnodes/simple/type/Type.java
@@ -43,7 +43,7 @@ public class Type {
 
     public boolean isConstant() { return _type == TTOP || _type == TXCTRL; }
 
-    public StringBuilder _print(StringBuilder sb) {return is_simple() ? sb.append(STRS[_type]) : sb;}
+    public StringBuilder print(StringBuilder sb) {return is_simple() ? sb.append(STRS[_type]) : sb;}
 
     public final Type meet(Type t) {
         // Shortcut for the self case
@@ -72,6 +72,6 @@ public class Type {
 
     @Override
     public final String toString() {
-        return _print(new StringBuilder()).toString();
+        return print(new StringBuilder()).toString();
     }
 }

--- a/chapter07/src/main/java/com/seaofnodes/simple/type/TypeInteger.java
+++ b/chapter07/src/main/java/com/seaofnodes/simple/type/TypeInteger.java
@@ -29,7 +29,7 @@ public class TypeInteger extends Type {
     public boolean isBot() { return !_is_con && _con==1; }
 
     @Override
-    public StringBuilder _print(StringBuilder sb) {
+    public StringBuilder print(StringBuilder sb) {
         if (isTop()) return sb.append("IntTop");
         if (isBot()) return sb.append("IntBot");
         return sb.append(_con);

--- a/chapter07/src/main/java/com/seaofnodes/simple/type/TypeTuple.java
+++ b/chapter07/src/main/java/com/seaofnodes/simple/type/TypeTuple.java
@@ -15,10 +15,10 @@ public class TypeTuple extends Type {
     }
 
     @Override
-    public StringBuilder _print(StringBuilder sb) {
+    public StringBuilder print(StringBuilder sb) {
         sb.append("[");
         for( Type t : _types )
-            t._print(sb).append(",");
+            t.print(sb).append(",");
         sb.setLength(sb.length()-1);
         sb.append("]");
         return sb;

--- a/chapter08/src/main/java/com/seaofnodes/simple/node/ConstantNode.java
+++ b/chapter08/src/main/java/com/seaofnodes/simple/node/ConstantNode.java
@@ -32,7 +32,7 @@ public class ConstantNode extends Node {
 
     @Override
     StringBuilder _print1(StringBuilder sb, BitSet visited) {
-        return _con._print(sb);
+        return _con.print(sb);
     }
 
     @Override public boolean isMultiTail() { return true; }

--- a/chapter08/src/main/java/com/seaofnodes/simple/node/Node.java
+++ b/chapter08/src/main/java/com/seaofnodes/simple/node/Node.java
@@ -136,7 +136,7 @@ public abstract class Node {
         for( int i = _outputs.size(); i<lim; i++ )
             sb.append("     ");
         sb.append(" ]]  ");
-        if( _type!= null ) _type._print(sb);
+        if( _type!= null ) _type.print(sb);
         sb.append("\n");
     }
 

--- a/chapter08/src/main/java/com/seaofnodes/simple/type/Type.java
+++ b/chapter08/src/main/java/com/seaofnodes/simple/type/Type.java
@@ -43,7 +43,7 @@ public class Type {
 
     public boolean isConstant() { return _type == TTOP || _type == TXCTRL; }
 
-    public StringBuilder _print(StringBuilder sb) {return is_simple() ? sb.append(STRS[_type]) : sb;}
+    public StringBuilder print(StringBuilder sb) {return is_simple() ? sb.append(STRS[_type]) : sb;}
 
     public final Type meet(Type t) {
         // Shortcut for the self case
@@ -72,6 +72,6 @@ public class Type {
 
     @Override
     public final String toString() {
-        return _print(new StringBuilder()).toString();
+        return print(new StringBuilder()).toString();
     }
 }

--- a/chapter08/src/main/java/com/seaofnodes/simple/type/TypeInteger.java
+++ b/chapter08/src/main/java/com/seaofnodes/simple/type/TypeInteger.java
@@ -29,7 +29,7 @@ public class TypeInteger extends Type {
     public boolean isBot() { return !_is_con && _con==1; }
 
     @Override
-    public StringBuilder _print(StringBuilder sb) {
+    public StringBuilder print(StringBuilder sb) {
         if (isTop()) return sb.append("IntTop");
         if (isBot()) return sb.append("IntBot");
         return sb.append(_con);

--- a/chapter08/src/main/java/com/seaofnodes/simple/type/TypeTuple.java
+++ b/chapter08/src/main/java/com/seaofnodes/simple/type/TypeTuple.java
@@ -15,10 +15,10 @@ public class TypeTuple extends Type {
     }
 
     @Override
-    public StringBuilder _print(StringBuilder sb) {
+    public StringBuilder print(StringBuilder sb) {
         sb.append("[");
         for( Type t : _types )
-            t._print(sb).append(",");
+            t.print(sb).append(",");
         sb.setLength(sb.length()-1);
         sb.append("]");
         return sb;

--- a/chapter09/src/main/java/com/seaofnodes/simple/node/ConstantNode.java
+++ b/chapter09/src/main/java/com/seaofnodes/simple/node/ConstantNode.java
@@ -32,7 +32,7 @@ public class ConstantNode extends Node {
 
     @Override
     StringBuilder _print1(StringBuilder sb, BitSet visited) {
-        return _con._print(sb);
+        return _con.print(sb);
     }
 
     @Override public boolean isMultiTail() { return true; }

--- a/chapter09/src/main/java/com/seaofnodes/simple/node/Node.java
+++ b/chapter09/src/main/java/com/seaofnodes/simple/node/Node.java
@@ -139,7 +139,7 @@ public abstract class Node {
         for( int i = _outputs.size(); i<lim; i++ )
             sb.append("     ");
         sb.append(" ]]  ");
-        if( _type!= null ) _type._print(sb);
+        if( _type!= null ) _type.print(sb);
         sb.append("\n");
     }
 

--- a/chapter09/src/main/java/com/seaofnodes/simple/type/Type.java
+++ b/chapter09/src/main/java/com/seaofnodes/simple/type/Type.java
@@ -52,7 +52,7 @@ public class Type {
     // Excludes both high and low values
     public boolean isConstant() { return false; }
 
-    public StringBuilder _print(StringBuilder sb) {return is_simple() ? sb.append(STRS[_type]) : sb;}
+    public StringBuilder print(StringBuilder sb) {return is_simple() ? sb.append(STRS[_type]) : sb;}
 
     // ----------------------------------------------------------
 
@@ -136,6 +136,6 @@ public class Type {
     // ----------------------------------------------------------
     @Override
     public final String toString() {
-        return _print(new StringBuilder()).toString();
+        return print(new StringBuilder()).toString();
     }
 }

--- a/chapter09/src/main/java/com/seaofnodes/simple/type/TypeInteger.java
+++ b/chapter09/src/main/java/com/seaofnodes/simple/type/TypeInteger.java
@@ -29,7 +29,7 @@ public class TypeInteger extends Type {
     public static TypeInteger constant(long con) { return make(true, con); }
 
     @Override
-    public StringBuilder _print(StringBuilder sb) {
+    public StringBuilder print(StringBuilder sb) {
         if( this==TOP ) return sb.append("IntTop");
         if( this==BOT ) return sb.append("IntBot");
         return sb.append(_con);

--- a/chapter09/src/main/java/com/seaofnodes/simple/type/TypeTuple.java
+++ b/chapter09/src/main/java/com/seaofnodes/simple/type/TypeTuple.java
@@ -25,10 +25,10 @@ public class TypeTuple extends Type {
     }
 
     @Override
-    public StringBuilder _print(StringBuilder sb) {
+    public StringBuilder print(StringBuilder sb) {
         sb.append("[");
         for( Type t : _types )
-            t._print(sb).append(",");
+            t.print(sb).append(",");
         sb.setLength(sb.length()-1);
         sb.append("]");
         return sb;

--- a/chapter10/src/main/java/com/seaofnodes/simple/node/ConstantNode.java
+++ b/chapter10/src/main/java/com/seaofnodes/simple/node/ConstantNode.java
@@ -32,7 +32,7 @@ public class ConstantNode extends Node {
 
     @Override
     StringBuilder _print1(StringBuilder sb, BitSet visited) {
-        return _con._print(sb);
+        return _con.print(sb);
     }
 
     @Override public boolean isMultiTail() { return true; }

--- a/chapter10/src/main/java/com/seaofnodes/simple/type/Field.java
+++ b/chapter10/src/main/java/com/seaofnodes/simple/type/Field.java
@@ -52,8 +52,8 @@ public class Field extends Type {
 
 
     @Override
-    public StringBuilder _print( StringBuilder sb ) {
-        return _type._print(sb.append(_fname).append(":"));
+    public StringBuilder print( StringBuilder sb ) {
+        return _type.print(sb.append(_fname).append(":"));
     }
 
     @Override public String str() { return _fname; }

--- a/chapter10/src/main/java/com/seaofnodes/simple/type/Type.java
+++ b/chapter10/src/main/java/com/seaofnodes/simple/type/Type.java
@@ -75,7 +75,7 @@ public class Type {
     /**
      * Display Type name in a format that's good for IR printer
      */
-    public StringBuilder typeName( StringBuilder sb) { return _print(sb); }
+    public StringBuilder typeName( StringBuilder sb) { return print(sb); }
 
     public Type makeInit() { return null; }
 
@@ -177,10 +177,10 @@ public class Type {
     // This is a more verbose dev-friendly print.
     @Override
     public final String toString() {
-        return _print(new StringBuilder()).toString();
+        return print(new StringBuilder()).toString();
     }
 
-    public StringBuilder _print(StringBuilder sb) { return is_simple() ? sb.append(STRS[_type]) : sb;}
+    public StringBuilder print(StringBuilder sb) { return is_simple() ? sb.append(STRS[_type]) : sb;}
 
     // This is used by error messages, and is a shorted print.
     public String str() { return STRS[_type]; }

--- a/chapter10/src/main/java/com/seaofnodes/simple/type/TypeInteger.java
+++ b/chapter10/src/main/java/com/seaofnodes/simple/type/TypeInteger.java
@@ -35,7 +35,7 @@ public class TypeInteger extends Type {
     // FIXME this display format is problematic
     // In visualizer '#' gets prepended if its a constant
     @Override
-    public StringBuilder _print(StringBuilder sb) {
+    public StringBuilder print(StringBuilder sb) {
         if( this==TOP ) return sb.append("IntTop");
         if( this==BOT ) return sb.append("IntBot");
         return sb.append(_con);

--- a/chapter10/src/main/java/com/seaofnodes/simple/type/TypeMem.java
+++ b/chapter10/src/main/java/com/seaofnodes/simple/type/TypeMem.java
@@ -52,7 +52,7 @@ public class TypeMem extends Type {
     }
 
     @Override
-    public StringBuilder _print(StringBuilder sb) {
+    public StringBuilder print(StringBuilder sb) {
         return sb.append("MEM#").append( switch(_alias) {
             case  0 -> "TOP";
             case -1 -> "BOT";
@@ -60,5 +60,5 @@ public class TypeMem extends Type {
             });
     }
 
-    @Override public String str() { return _print(new StringBuilder()).toString(); }
+    @Override public String str() { return print(new StringBuilder()).toString(); }
 }

--- a/chapter10/src/main/java/com/seaofnodes/simple/type/TypeMemPtr.java
+++ b/chapter10/src/main/java/com/seaofnodes/simple/type/TypeMemPtr.java
@@ -63,10 +63,10 @@ public class TypeMemPtr extends Type {
 
     // [void,name,MANY]*[,?]
     @Override
-    public StringBuilder _print(StringBuilder sb) {
+    public StringBuilder print(StringBuilder sb) {
         if( this== NULLPTR) return sb.append("null");
         if( this== VOIDPTR) return sb.append("*void");
-        return _obj._print(sb.append("*")).append(_nil ? "?" : "");
+        return _obj.print(sb.append("*")).append(_nil ? "?" : "");
     }
 
     @Override public String str() {

--- a/chapter10/src/main/java/com/seaofnodes/simple/type/TypeStruct.java
+++ b/chapter10/src/main/java/com/seaofnodes/simple/type/TypeStruct.java
@@ -107,11 +107,11 @@ public class TypeStruct extends Type {
     }
 
     @Override
-    public StringBuilder _print(StringBuilder sb) {
+    public StringBuilder print(StringBuilder sb) {
         sb.append(_name).append(" {\n");
         for( Field f : _fields ) {
             sb.append("  ").append(f._fname).append(":");
-            f._type._print(sb);
+            f._type.print(sb);
             sb.append(";\n");
         }
         return sb.append("}");

--- a/chapter10/src/main/java/com/seaofnodes/simple/type/TypeTuple.java
+++ b/chapter10/src/main/java/com/seaofnodes/simple/type/TypeTuple.java
@@ -38,16 +38,16 @@ public class TypeTuple extends Type {
     }
 
     @Override
-    public StringBuilder _print(StringBuilder sb) {
+    public StringBuilder print(StringBuilder sb) {
         sb.append("[");
         for( Type t : _types )
-            t._print(sb).append(",");
+            t.print(sb).append(",");
         sb.setLength(sb.length()-1);
         sb.append("]");
         return sb;
     }
 
-    @Override public String str() { return _print(new StringBuilder()).toString(); }
+    @Override public String str() { return print(new StringBuilder()).toString(); }
 
     /**
      * Display Type name in a format that's good for IR printer

--- a/chapter11/src/main/java/com/seaofnodes/simple/node/ConstantNode.java
+++ b/chapter11/src/main/java/com/seaofnodes/simple/node/ConstantNode.java
@@ -32,7 +32,7 @@ public class ConstantNode extends Node {
 
     @Override
     StringBuilder _print1(StringBuilder sb, BitSet visited) {
-        return _con._print(sb);
+        return _con.print(sb);
     }
 
     @Override public boolean isMultiTail() { return true; }

--- a/chapter11/src/main/java/com/seaofnodes/simple/type/Field.java
+++ b/chapter11/src/main/java/com/seaofnodes/simple/type/Field.java
@@ -52,8 +52,8 @@ public class Field extends Type {
 
 
     @Override
-    public StringBuilder _print( StringBuilder sb ) {
-        return _type._print(sb.append(_fname).append(":"));
+    public StringBuilder print( StringBuilder sb ) {
+        return _type.print(sb.append(_fname).append(":"));
     }
 
     @Override public String str() { return _fname; }

--- a/chapter11/src/main/java/com/seaofnodes/simple/type/Type.java
+++ b/chapter11/src/main/java/com/seaofnodes/simple/type/Type.java
@@ -75,7 +75,7 @@ public class Type {
     /**
      * Display Type name in a format that's good for IR printer
      */
-    public StringBuilder typeName( StringBuilder sb) { return _print(sb); }
+    public StringBuilder typeName( StringBuilder sb) { return print(sb); }
 
     public Type makeInit() { return null; }
 
@@ -177,10 +177,10 @@ public class Type {
     // This is a more verbose dev-friendly print.
     @Override
     public final String toString() {
-        return _print(new StringBuilder()).toString();
+        return print(new StringBuilder()).toString();
     }
 
-    public StringBuilder _print(StringBuilder sb) { return is_simple() ? sb.append(STRS[_type]) : sb;}
+    public StringBuilder print(StringBuilder sb) { return is_simple() ? sb.append(STRS[_type]) : sb;}
 
     // This is used by error messages, and is a shorted print.
     public String str() { return STRS[_type]; }

--- a/chapter11/src/main/java/com/seaofnodes/simple/type/TypeInteger.java
+++ b/chapter11/src/main/java/com/seaofnodes/simple/type/TypeInteger.java
@@ -35,7 +35,7 @@ public class TypeInteger extends Type {
     // FIXME this display format is problematic
     // In visualizer '#' gets prepended if its a constant
     @Override
-    public StringBuilder _print(StringBuilder sb) {
+    public StringBuilder print(StringBuilder sb) {
         if( this==TOP ) return sb.append("IntTop");
         if( this==BOT ) return sb.append("IntBot");
         return sb.append(_con);

--- a/chapter11/src/main/java/com/seaofnodes/simple/type/TypeMem.java
+++ b/chapter11/src/main/java/com/seaofnodes/simple/type/TypeMem.java
@@ -52,7 +52,7 @@ public class TypeMem extends Type {
     }
 
     @Override
-    public StringBuilder _print(StringBuilder sb) {
+    public StringBuilder print(StringBuilder sb) {
         return sb.append("MEM#").append( switch(_alias) {
             case  0 -> "TOP";
             case -1 -> "BOT";
@@ -60,5 +60,5 @@ public class TypeMem extends Type {
             });
     }
 
-    @Override public String str() { return _print(new StringBuilder()).toString(); }
+    @Override public String str() { return print(new StringBuilder()).toString(); }
 }

--- a/chapter11/src/main/java/com/seaofnodes/simple/type/TypeMemPtr.java
+++ b/chapter11/src/main/java/com/seaofnodes/simple/type/TypeMemPtr.java
@@ -63,10 +63,10 @@ public class TypeMemPtr extends Type {
 
     // [void,name,MANY]*[,?]
     @Override
-    public StringBuilder _print(StringBuilder sb) {
+    public StringBuilder print(StringBuilder sb) {
         if( this== NULLPTR) return sb.append("null");
         if( this== VOIDPTR) return sb.append("*void");
-        return _obj._print(sb.append("*")).append(_nil ? "?" : "");
+        return _obj.print(sb.append("*")).append(_nil ? "?" : "");
     }
 
     @Override public String str() {

--- a/chapter11/src/main/java/com/seaofnodes/simple/type/TypeStruct.java
+++ b/chapter11/src/main/java/com/seaofnodes/simple/type/TypeStruct.java
@@ -107,11 +107,11 @@ public class TypeStruct extends Type {
     }
 
     @Override
-    public StringBuilder _print(StringBuilder sb) {
+    public StringBuilder print(StringBuilder sb) {
         sb.append(_name).append(" {\n");
         for( Field f : _fields ) {
             sb.append("  ").append(f._fname).append(":");
-            f._type._print(sb);
+            f._type.print(sb);
             sb.append(";\n");
         }
         return sb.append("}");

--- a/chapter11/src/main/java/com/seaofnodes/simple/type/TypeTuple.java
+++ b/chapter11/src/main/java/com/seaofnodes/simple/type/TypeTuple.java
@@ -38,16 +38,16 @@ public class TypeTuple extends Type {
     }
 
     @Override
-    public StringBuilder _print(StringBuilder sb) {
+    public StringBuilder print(StringBuilder sb) {
         sb.append("[");
         for( Type t : _types )
-            t._print(sb).append(",");
+            t.print(sb).append(",");
         sb.setLength(sb.length()-1);
         sb.append("]");
         return sb;
     }
 
-    @Override public String str() { return _print(new StringBuilder()).toString(); }
+    @Override public String str() { return print(new StringBuilder()).toString(); }
 
     /**
      * Display Type name in a format that's good for IR printer

--- a/chapter12/src/main/java/com/seaofnodes/simple/node/ConstantNode.java
+++ b/chapter12/src/main/java/com/seaofnodes/simple/node/ConstantNode.java
@@ -32,7 +32,7 @@ public class ConstantNode extends Node {
 
     @Override
     StringBuilder _print1(StringBuilder sb, BitSet visited) {
-        return _con._print(sb);
+        return _con.print(sb);
     }
 
     @Override public boolean isMultiTail() { return true; }

--- a/chapter12/src/main/java/com/seaofnodes/simple/type/Field.java
+++ b/chapter12/src/main/java/com/seaofnodes/simple/type/Field.java
@@ -52,8 +52,8 @@ public class Field extends Type {
 
 
     @Override
-    public StringBuilder _print( StringBuilder sb ) {
-        return _type._print(sb.append(_fname).append(":"));
+    public StringBuilder print( StringBuilder sb ) {
+        return _type.print(sb.append(_fname).append(":"));
     }
 
     @Override public String str() { return _fname; }

--- a/chapter12/src/main/java/com/seaofnodes/simple/type/Type.java
+++ b/chapter12/src/main/java/com/seaofnodes/simple/type/Type.java
@@ -76,7 +76,7 @@ public class Type {
     /**
      * Display Type name in a format that's good for IR printer
      */
-    public StringBuilder typeName( StringBuilder sb) { return _print(sb); }
+    public StringBuilder typeName( StringBuilder sb) { return print(sb); }
 
     public Type makeInit() { return null; }
 
@@ -178,10 +178,10 @@ public class Type {
     // This is a more verbose dev-friendly print.
     @Override
     public final String toString() {
-        return _print(new StringBuilder()).toString();
+        return print(new StringBuilder()).toString();
     }
 
-    public StringBuilder _print(StringBuilder sb) { return is_simple() ? sb.append(STRS[_type]) : sb;}
+    public StringBuilder print(StringBuilder sb) { return is_simple() ? sb.append(STRS[_type]) : sb;}
 
     // This is used by error messages, and is a shorted print.
     public String str() { return STRS[_type]; }

--- a/chapter12/src/main/java/com/seaofnodes/simple/type/TypeFloat.java
+++ b/chapter12/src/main/java/com/seaofnodes/simple/type/TypeFloat.java
@@ -35,7 +35,7 @@ public class TypeFloat extends Type {
     // FIXME this display format is problematic
     // In visualizer '#' gets prepended if its a constant
     @Override
-    public StringBuilder _print(StringBuilder sb) {
+    public StringBuilder print(StringBuilder sb) {
         if( this==TOP ) return sb.append("FltTop");
         if( this==BOT ) return sb.append("FltBot");
         return sb.append(_con);

--- a/chapter12/src/main/java/com/seaofnodes/simple/type/TypeInteger.java
+++ b/chapter12/src/main/java/com/seaofnodes/simple/type/TypeInteger.java
@@ -35,7 +35,7 @@ public class TypeInteger extends Type {
     // FIXME this display format is problematic
     // In visualizer '#' gets prepended if its a constant
     @Override
-    public StringBuilder _print(StringBuilder sb) {
+    public StringBuilder print(StringBuilder sb) {
         if( this==TOP ) return sb.append("IntTop");
         if( this==BOT ) return sb.append("IntBot");
         return sb.append(_con);

--- a/chapter12/src/main/java/com/seaofnodes/simple/type/TypeMem.java
+++ b/chapter12/src/main/java/com/seaofnodes/simple/type/TypeMem.java
@@ -52,7 +52,7 @@ public class TypeMem extends Type {
     }
 
     @Override
-    public StringBuilder _print(StringBuilder sb) {
+    public StringBuilder print(StringBuilder sb) {
         return sb.append("MEM#").append( switch(_alias) {
             case  0 -> "TOP";
             case -1 -> "BOT";
@@ -60,5 +60,5 @@ public class TypeMem extends Type {
             });
     }
 
-    @Override public String str() { return _print(new StringBuilder()).toString(); }
+    @Override public String str() { return print(new StringBuilder()).toString(); }
 }

--- a/chapter12/src/main/java/com/seaofnodes/simple/type/TypeMemPtr.java
+++ b/chapter12/src/main/java/com/seaofnodes/simple/type/TypeMemPtr.java
@@ -63,10 +63,10 @@ public class TypeMemPtr extends Type {
 
     // [void,name,MANY]*[,?]
     @Override
-    public StringBuilder _print(StringBuilder sb) {
+    public StringBuilder print(StringBuilder sb) {
         if( this== NULLPTR) return sb.append("null");
         if( this== VOIDPTR) return sb.append("*void");
-        return _obj._print(sb.append("*")).append(_nil ? "?" : "");
+        return _obj.print(sb.append("*")).append(_nil ? "?" : "");
     }
 
     @Override public String str() {

--- a/chapter12/src/main/java/com/seaofnodes/simple/type/TypeStruct.java
+++ b/chapter12/src/main/java/com/seaofnodes/simple/type/TypeStruct.java
@@ -107,11 +107,11 @@ public class TypeStruct extends Type {
     }
 
     @Override
-    public StringBuilder _print(StringBuilder sb) {
+    public StringBuilder print(StringBuilder sb) {
         sb.append(_name).append(" {\n");
         for( Field f : _fields ) {
             sb.append("  ").append(f._fname).append(":");
-            f._type._print(sb);
+            f._type.print(sb);
             sb.append(";\n");
         }
         return sb.append("}");

--- a/chapter12/src/main/java/com/seaofnodes/simple/type/TypeTuple.java
+++ b/chapter12/src/main/java/com/seaofnodes/simple/type/TypeTuple.java
@@ -38,16 +38,16 @@ public class TypeTuple extends Type {
     }
 
     @Override
-    public StringBuilder _print(StringBuilder sb) {
+    public StringBuilder print(StringBuilder sb) {
         sb.append("[");
         for( Type t : _types )
-            t._print(sb).append(",");
+            t.print(sb).append(",");
         sb.setLength(sb.length()-1);
         sb.append("]");
         return sb;
     }
 
-    @Override public String str() { return _print(new StringBuilder()).toString(); }
+    @Override public String str() { return print(new StringBuilder()).toString(); }
 
     /**
      * Display Type name in a format that's good for IR printer


### PR DESCRIPTION
`_print()` in Type class was renamed to `print()` in Chapter13 without functionality changes. Backport the renaming to reduce noise in diff viewing.