### PR TITLE
Fix typo: spline -> spine in AddNode (chapters 4-8)

### DIFF
--- a/chapter04/src/main/java/com/seaofnodes/simple/node/AddNode.java
+++ b/chapter04/src/main/java/com/seaofnodes/simple/node/AddNode.java
@@ -63,7 +63,7 @@ public class AddNode extends Node {
 
         // Now we might see (add add non) or (add non non) but never (add non add) nor (add add add)
         if( !(lhs instanceof AddNode) )
-            return spline_cmp(lhs,rhs) ? swap12() : null;
+            return spine_cmp(lhs,rhs) ? swap12() : null;
 
         // Now we only see (add add non)
 
@@ -72,22 +72,22 @@ public class AddNode extends Node {
         if( lhs.in(2)._type.isConstant() && t2.isConstant() )
             return new AddNode(lhs.in(1),new AddNode(lhs.in(2),rhs).peephole());
 
-        // Now we sort along the spline via rotates, to gather similar things together.
+        // Now we sort along the spine via rotates, to gather similar things together.
 
         // Do we rotate (x + y) + z
         // into         (x + z) + y ?
-        if( spline_cmp(lhs.in(2),rhs) )
+        if( spine_cmp(lhs.in(2),rhs) )
             return new AddNode(new AddNode(lhs.in(1),rhs).peephole(),lhs.in(2));
 
         return null;
     }
 
-    // Compare two off-spline nodes and decide what order they should be in.
+    // Compare two off-spine nodes and decide what order they should be in.
     // Do we rotate ((x + hi) + lo) into ((x + lo) + hi) ?
     // Generally constants always go right, then others.
     // Ties with in a category sort by node ID.
     // TRUE if swapping hi and lo.
-    static boolean spline_cmp( Node hi, Node lo ) {
+    static boolean spine_cmp( Node hi, Node lo ) {
         if( lo._type.isConstant() ) return false;
         if( hi._type.isConstant() ) return true ;
 

--- a/chapter05/src/main/java/com/seaofnodes/simple/node/AddNode.java
+++ b/chapter05/src/main/java/com/seaofnodes/simple/node/AddNode.java
@@ -63,7 +63,7 @@ public class AddNode extends Node {
 
         // Now we might see (add add non) or (add non non) but never (add non add) nor (add add add)
         if( !(lhs instanceof AddNode) )
-            return spline_cmp(lhs,rhs) ? swap12() : null;
+            return spine_cmp(lhs,rhs) ? swap12() : null;
 
         // Now we only see (add add non)
 
@@ -90,22 +90,22 @@ public class AddNode extends Node {
             return new AddNode(lhs.in(1),new PhiNode(label,ns).peephole());
         }
 
-        // Now we sort along the spline via rotates, to gather similar things together.
+        // Now we sort along the spine via rotates, to gather similar things together.
 
         // Do we rotate (x + y) + z
         // into         (x + z) + y ?
-        if( spline_cmp(lhs.in(2),rhs) )
+        if( spine_cmp(lhs.in(2),rhs) )
             return new AddNode(new AddNode(lhs.in(1),rhs).peephole(),lhs.in(2));
 
         return null;
     }
 
-    // Compare two off-spline nodes and decide what order they should be in.
+    // Compare two off-spine nodes and decide what order they should be in.
     // Do we rotate ((x + hi) + lo) into ((x + lo) + hi) ?
     // Generally constants always go right, then Phi-of-constants, then muls, then others.
     // Ties with in a category sort by node ID.
     // TRUE if swapping hi and lo.
-    static boolean spline_cmp( Node hi, Node lo ) {
+    static boolean spine_cmp( Node hi, Node lo ) {
         if( lo._type.isConstant() ) return false;
         if( hi._type.isConstant() ) return true ;
 

--- a/chapter06/src/main/java/com/seaofnodes/simple/node/AddNode.java
+++ b/chapter06/src/main/java/com/seaofnodes/simple/node/AddNode.java
@@ -64,7 +64,7 @@ public class AddNode extends Node {
         // Now we might see (add add non) or (add non non) but never (add non add) nor (add add add)
         if( !(lhs instanceof AddNode) )
             // Rotate; look for (add (phi cons) con/(phi cons))
-            return spline_cmp(lhs,rhs) ? swap12() : phiCon(this,true);
+            return spine_cmp(lhs,rhs) ? swap12() : phiCon(this,true);
 
         // Now we only see (add add non)
 
@@ -80,11 +80,11 @@ public class AddNode extends Node {
         Node phicon = phiCon(this,true);
         if( phicon!=null ) return phicon;
 
-        // Now we sort along the spline via rotates, to gather similar things together.
+        // Now we sort along the spine via rotates, to gather similar things together.
 
         // Do we rotate (x + y) + z
         // into         (x + z) + y ?
-        if( spline_cmp(lhs.in(2),rhs) )
+        if( spine_cmp(lhs.in(2),rhs) )
             return new AddNode(new AddNode(lhs.in(1),rhs).peephole(),lhs.in(2));
 
         return null;
@@ -131,12 +131,12 @@ public class AddNode extends Node {
         return op instanceof PhiNode phi && phi.allCons() ? phi : null;
     }
 
-    // Compare two off-spline nodes and decide what order they should be in.
+    // Compare two off-spine nodes and decide what order they should be in.
     // Do we rotate ((x + hi) + lo) into ((x + lo) + hi) ?
     // Generally constants always go right, then Phi-of-constants, then muls, then others.
     // Ties with in a category sort by node ID.
     // TRUE if swapping hi and lo.
-    static boolean spline_cmp( Node hi, Node lo ) {
+    static boolean spine_cmp( Node hi, Node lo ) {
         if( lo._type.isConstant() ) return false;
         if( hi._type.isConstant() ) return true ;
 

--- a/chapter07/src/main/java/com/seaofnodes/simple/node/AddNode.java
+++ b/chapter07/src/main/java/com/seaofnodes/simple/node/AddNode.java
@@ -66,7 +66,7 @@ public class AddNode extends Node {
         // Now we might see (add add non) or (add non non) but never (add non add) nor (add add add)
         if( !(lhs instanceof AddNode) )
             // Rotate; look for (add (phi cons) con/(phi cons))
-            return spline_cmp(lhs,rhs) ? swap12() : phiCon(this,true);
+            return spine_cmp(lhs,rhs) ? swap12() : phiCon(this,true);
 
         // Now we only see (add add non)
 
@@ -82,11 +82,11 @@ public class AddNode extends Node {
         Node phicon = phiCon(this,true);
         if( phicon!=null ) return phicon;
 
-        // Now we sort along the spline via rotates, to gather similar things together.
+        // Now we sort along the spine via rotates, to gather similar things together.
 
         // Do we rotate (x + y) + z
         // into         (x + z) + y ?
-        if( spline_cmp(lhs.in(2),rhs) )
+        if( spine_cmp(lhs.in(2),rhs) )
             return new AddNode(new AddNode(lhs.in(1),rhs).peephole(),lhs.in(2));
 
         return null;
@@ -133,12 +133,12 @@ public class AddNode extends Node {
         return op instanceof PhiNode phi && phi.allCons() ? phi : null;
     }
 
-    // Compare two off-spline nodes and decide what order they should be in.
+    // Compare two off-spine nodes and decide what order they should be in.
     // Do we rotate ((x + hi) + lo) into ((x + lo) + hi) ?
     // Generally constants always go right, then Phi-of-constants, then muls, then others.
     // Ties with in a category sort by node ID.
     // TRUE if swapping hi and lo.
-    static boolean spline_cmp( Node hi, Node lo ) {
+    static boolean spine_cmp( Node hi, Node lo ) {
         if( lo._type.isConstant() ) return false;
         if( hi._type.isConstant() ) return true ;
 

--- a/chapter08/src/main/java/com/seaofnodes/simple/node/AddNode.java
+++ b/chapter08/src/main/java/com/seaofnodes/simple/node/AddNode.java
@@ -66,7 +66,7 @@ public class AddNode extends Node {
         // Now we might see (add add non) or (add non non) but never (add non add) nor (add add add)
         if( !(lhs instanceof AddNode) )
             // Rotate; look for (add (phi cons) con/(phi cons))
-            return spline_cmp(lhs,rhs) ? swap12() : phiCon(this,true);
+            return spine_cmp(lhs,rhs) ? swap12() : phiCon(this,true);
 
         // Now we only see (add add non)
 
@@ -87,11 +87,11 @@ public class AddNode extends Node {
         Node phicon = phiCon(this,true);
         if( phicon!=null ) return phicon;
 
-        // Now we sort along the spline via rotates, to gather similar things together.
+        // Now we sort along the spine via rotates, to gather similar things together.
 
         // Do we rotate (x + y) + z
         // into         (x + z) + y ?
-        if( spline_cmp(lhs.in(2),rhs) )
+        if( spine_cmp(lhs.in(2),rhs) )
             return new AddNode(new AddNode(lhs.in(1),rhs).peephole(),lhs.in(2));
 
         return null;
@@ -138,12 +138,12 @@ public class AddNode extends Node {
         return op instanceof PhiNode phi && phi.allCons() ? phi : null;
     }
 
-    // Compare two off-spline nodes and decide what order they should be in.
+    // Compare two off-spine nodes and decide what order they should be in.
     // Do we rotate ((x + hi) + lo) into ((x + lo) + hi) ?
     // Generally constants always go right, then Phi-of-constants, then muls, then others.
     // Ties with in a category sort by node ID.
     // TRUE if swapping hi and lo.
-    static boolean spline_cmp( Node hi, Node lo ) {
+    static boolean spine_cmp( Node hi, Node lo ) {
         if( lo._type.isConstant() ) return false;
         if( hi._type.isConstant() ) return true ;
 


### PR DESCRIPTION
The add canonicalization builds a left-leaning chain of AddNodes -- the "spine" -- with off-spine operands hanging off each in(2). The comparator and its comments were spelled "spline" (a curve / mechanical part), which was already inconsistent with the goal comment in the same method:

    // Goal: a left-spine set of adds, with constants on the rhs

Chapters 9 and later already use "spine" / "spine_cmp"; this brings the earlier chapters in line.

Comment and private-method-name only, no behavior change.