### PR TITLE
Fix stale copy-pasted comment on BoolNode's phiCon call

### DIFF
--- a/chapter06/src/main/java/com/seaofnodes/simple/node/BoolNode.java
+++ b/chapter06/src/main/java/com/seaofnodes/simple/node/BoolNode.java
@@ -43,9 +43,10 @@ abstract public class BoolNode extends Node {
         if( in(1)==in(2) )
             return new ConstantNode(TypeInteger.constant(doOp(3,3)?1:0));
 
-        // Do we have ((x * (phi cons)) * con) ?
-        // Do we have ((x * (phi cons)) * (phi cons)) ?
-        // Push constant up through the phi: x * (phi con0*con0 con1*con1...)
+        // Do we have ((phi cons) cmp con) ?
+        // Do we have ((phi cons) cmp (phi cons)) ?
+        // Push the compare up through the phi: (phi con0 cmp con, con1 cmp con...)
+        // No rotate: compares are not associative.
         Node phicon = AddNode.phiCon(this,false);
         if( phicon!=null ) return phicon;
 

--- a/chapter07/src/main/java/com/seaofnodes/simple/node/BoolNode.java
+++ b/chapter07/src/main/java/com/seaofnodes/simple/node/BoolNode.java
@@ -45,9 +45,10 @@ abstract public class BoolNode extends Node {
         if( in(1)==in(2) )
             return new ConstantNode(TypeInteger.constant(doOp(3,3)?1:0));
 
-        // Do we have ((x * (phi cons)) * con) ?
-        // Do we have ((x * (phi cons)) * (phi cons)) ?
-        // Push constant up through the phi: x * (phi con0*con0 con1*con1...)
+        // Do we have ((phi cons) cmp con) ?
+        // Do we have ((phi cons) cmp (phi cons)) ?
+        // Push the compare up through the phi: (phi con0 cmp con, con1 cmp con...)
+        // No rotate: compares are not associative.
         Node phicon = AddNode.phiCon(this,false);
         if( phicon!=null ) return phicon;
 

--- a/chapter08/src/main/java/com/seaofnodes/simple/node/BoolNode.java
+++ b/chapter08/src/main/java/com/seaofnodes/simple/node/BoolNode.java
@@ -45,9 +45,10 @@ abstract public class BoolNode extends Node {
         if( in(1)==in(2) )
             return new ConstantNode(TypeInteger.constant(doOp(3,3)?1:0));
 
-        // Do we have ((x * (phi cons)) * con) ?
-        // Do we have ((x * (phi cons)) * (phi cons)) ?
-        // Push constant up through the phi: x * (phi con0*con0 con1*con1...)
+        // Do we have ((phi cons) cmp con) ?
+        // Do we have ((phi cons) cmp (phi cons)) ?
+        // Push the compare up through the phi: (phi con0 cmp con, con1 cmp con...)
+        // No rotate: compares are not associative.
         Node phicon = AddNode.phiCon(this,false);
         if( phicon!=null ) return phicon;
 

--- a/chapter09/src/main/java/com/seaofnodes/simple/node/BoolNode.java
+++ b/chapter09/src/main/java/com/seaofnodes/simple/node/BoolNode.java
@@ -44,9 +44,10 @@ abstract public class BoolNode extends Node {
         if( in(1)==in(2) )
             return new ConstantNode(TypeInteger.constant(doOp(3,3)?1:0));
 
-        // Do we have ((x * (phi cons)) * con) ?
-        // Do we have ((x * (phi cons)) * (phi cons)) ?
-        // Push constant up through the phi: x * (phi con0*con0 con1*con1...)
+        // Do we have ((phi cons) cmp con) ?
+        // Do we have ((phi cons) cmp (phi cons)) ?
+        // Push the compare up through the phi: (phi con0 cmp con, con1 cmp con...)
+        // No rotate: compares are not associative.
         Node phicon = AddNode.phiCon(this,false);
         if( phicon!=null ) return phicon;
 

--- a/chapter10/src/main/java/com/seaofnodes/simple/node/BoolNode.java
+++ b/chapter10/src/main/java/com/seaofnodes/simple/node/BoolNode.java
@@ -60,9 +60,9 @@ abstract public class BoolNode extends Node {
                 return new NotNode(in(1));
         }
 
-        // Do we have ((x * (phi cons)) * con) ?
-        // Do we have ((x * (phi cons)) * (phi cons)) ?
-        // Push constant up through the phi: x * (phi con0*con0 con1*con1...)
+        // Do we have ((phi cons) cmp con) ?
+        // Do we have ((phi cons) cmp (phi cons)) ?
+        // Push the compare up through the phi: (phi con0 cmp con, con1 cmp con...)
         Node phicon = AddNode.phiCon(this,this instanceof EQ);
         if( phicon!=null ) return phicon;
 

--- a/chapter11/src/main/java/com/seaofnodes/simple/node/BoolNode.java
+++ b/chapter11/src/main/java/com/seaofnodes/simple/node/BoolNode.java
@@ -60,9 +60,9 @@ abstract public class BoolNode extends Node {
                 return new NotNode(in(1));
         }
 
-        // Do we have ((x * (phi cons)) * con) ?
-        // Do we have ((x * (phi cons)) * (phi cons)) ?
-        // Push constant up through the phi: x * (phi con0*con0 con1*con1...)
+        // Do we have ((phi cons) cmp con) ?
+        // Do we have ((phi cons) cmp (phi cons)) ?
+        // Push the compare up through the phi: (phi con0 cmp con, con1 cmp con...)
         Node phicon = AddNode.phiCon(this,this instanceof EQ);
         if( phicon!=null ) return phicon;
 

--- a/chapter12/src/main/java/com/seaofnodes/simple/node/BoolNode.java
+++ b/chapter12/src/main/java/com/seaofnodes/simple/node/BoolNode.java
@@ -67,9 +67,9 @@ abstract public class BoolNode extends Node {
                 return new NotNode(in(1));
         }
 
-        // Do we have ((x * (phi cons)) * con) ?
-        // Do we have ((x * (phi cons)) * (phi cons)) ?
-        // Push constant up through the phi: x * (phi con0*con0 con1*con1...)
+        // Do we have ((phi cons) cmp con) ?
+        // Do we have ((phi cons) cmp (phi cons)) ?
+        // Push the compare up through the phi: (phi con0 cmp con, con1 cmp con...)
         Node phicon = AddNode.phiCon(this,this instanceof EQ);
         if( phicon!=null ) return phicon;
 

--- a/chapter13/src/main/java/com/seaofnodes/simple/node/BoolNode.java
+++ b/chapter13/src/main/java/com/seaofnodes/simple/node/BoolNode.java
@@ -67,9 +67,9 @@ abstract public class BoolNode extends Node {
                 return new NotNode(in(1));
         }
 
-        // Do we have ((x * (phi cons)) * con) ?
-        // Do we have ((x * (phi cons)) * (phi cons)) ?
-        // Push constant up through the phi: x * (phi con0*con0 con1*con1...)
+        // Do we have ((phi cons) cmp con) ?
+        // Do we have ((phi cons) cmp (phi cons)) ?
+        // Push the compare up through the phi: (phi con0 cmp con, con1 cmp con...)
         Node phicon = AddNode.phiCon(this,this instanceof EQ);
         if( phicon!=null ) return phicon;
 

--- a/chapter15/src/main/java/com/seaofnodes/simple/node/BoolNode.java
+++ b/chapter15/src/main/java/com/seaofnodes/simple/node/BoolNode.java
@@ -69,9 +69,9 @@ abstract public class BoolNode extends Node {
                 return new NotNode(in(1));
         }
 
-        // Do we have ((x * (phi cons)) * con) ?
-        // Do we have ((x * (phi cons)) * (phi cons)) ?
-        // Push constant up through the phi: x * (phi con0*con0 con1*con1...)
+        // Do we have ((phi cons) cmp con) ?
+        // Do we have ((phi cons) cmp (phi cons)) ?
+        // Push the compare up through the phi: (phi con0 cmp con, con1 cmp con...)
         Node phicon = AddNode.phiCon(this,this instanceof EQ);
         if( phicon!=null ) return phicon;
 

--- a/chapter16/src/main/java/com/seaofnodes/simple/node/BoolNode.java
+++ b/chapter16/src/main/java/com/seaofnodes/simple/node/BoolNode.java
@@ -69,9 +69,9 @@ abstract public class BoolNode extends Node {
                 return new NotNode(in(1));
         }
 
-        // Do we have ((x * (phi cons)) * con) ?
-        // Do we have ((x * (phi cons)) * (phi cons)) ?
-        // Push constant up through the phi: x * (phi con0*con0 con1*con1...)
+        // Do we have ((phi cons) cmp con) ?
+        // Do we have ((phi cons) cmp (phi cons)) ?
+        // Push the compare up through the phi: (phi con0 cmp con, con1 cmp con...)
         Node phicon = AddNode.phiCon(this,this instanceof EQ);
         if( phicon!=null ) return phicon;
 

--- a/chapter17/src/main/java/com/seaofnodes/simple/node/BoolNode.java
+++ b/chapter17/src/main/java/com/seaofnodes/simple/node/BoolNode.java
@@ -69,9 +69,9 @@ abstract public class BoolNode extends Node {
                 return new NotNode(in(1));
         }
 
-        // Do we have ((x * (phi cons)) * con) ?
-        // Do we have ((x * (phi cons)) * (phi cons)) ?
-        // Push constant up through the phi: x * (phi con0*con0 con1*con1...)
+        // Do we have ((phi cons) cmp con) ?
+        // Do we have ((phi cons) cmp (phi cons)) ?
+        // Push the compare up through the phi: (phi con0 cmp con, con1 cmp con...)
         Node phicon = AddNode.phiCon(this,this instanceof EQ);
         if( phicon!=null ) return phicon;
 

--- a/chapter18/src/main/java/com/seaofnodes/simple/node/BoolNode.java
+++ b/chapter18/src/main/java/com/seaofnodes/simple/node/BoolNode.java
@@ -70,9 +70,9 @@ abstract public class BoolNode extends Node {
                 return new NotNode(in(1));
         }
 
-        // Do we have ((x * (phi cons)) * con) ?
-        // Do we have ((x * (phi cons)) * (phi cons)) ?
-        // Push constant up through the phi: x * (phi con0*con0 con1*con1...)
+        // Do we have ((phi cons) cmp con) ?
+        // Do we have ((phi cons) cmp (phi cons)) ?
+        // Push the compare up through the phi: (phi con0 cmp con, con1 cmp con...)
         Node phicon = AddNode.phiCon(this,this instanceof EQ);
         if( phicon!=null ) return phicon;
 

--- a/chapter19/src/main/java/com/seaofnodes/simple/node/BoolNode.java
+++ b/chapter19/src/main/java/com/seaofnodes/simple/node/BoolNode.java
@@ -69,9 +69,9 @@ abstract public class BoolNode extends Node {
                 return new NotNode(in(1));
         }
 
-        // Do we have ((x * (phi cons)) * con) ?
-        // Do we have ((x * (phi cons)) * (phi cons)) ?
-        // Push constant up through the phi: x * (phi con0*con0 con1*con1...)
+        // Do we have ((phi cons) cmp con) ?
+        // Do we have ((phi cons) cmp (phi cons)) ?
+        // Push the compare up through the phi: (phi con0 cmp con, con1 cmp con...)
         Node phicon = AddNode.phiCon(this,this instanceof EQ);
         if( phicon!=null ) return phicon;
 

--- a/chapter20/src/main/java/com/seaofnodes/simple/node/BoolNode.java
+++ b/chapter20/src/main/java/com/seaofnodes/simple/node/BoolNode.java
@@ -71,9 +71,9 @@ abstract public class BoolNode extends Node {
                 return new NotNode(in(1));
         }
 
-        // Do we have ((x * (phi cons)) * con) ?
-        // Do we have ((x * (phi cons)) * (phi cons)) ?
-        // Push constant up through the phi: x * (phi con0*con0 con1*con1...)
+        // Do we have ((phi cons) cmp con) ?
+        // Do we have ((phi cons) cmp (phi cons)) ?
+        // Push the compare up through the phi: (phi con0 cmp con, con1 cmp con...)
         Node phicon = AddNode.phiCon(this,this instanceof EQ);
         if( phicon!=null ) return phicon;
 

--- a/chapter21/src/main/java/com/seaofnodes/simple/node/BoolNode.java
+++ b/chapter21/src/main/java/com/seaofnodes/simple/node/BoolNode.java
@@ -71,9 +71,9 @@ abstract public class BoolNode extends Node {
                 return new NotNode(in(1));
         }
 
-        // Do we have ((x * (phi cons)) * con) ?
-        // Do we have ((x * (phi cons)) * (phi cons)) ?
-        // Push constant up through the phi: x * (phi con0*con0 con1*con1...)
+        // Do we have ((phi cons) cmp con) ?
+        // Do we have ((phi cons) cmp (phi cons)) ?
+        // Push the compare up through the phi: (phi con0 cmp con, con1 cmp con...)
         Node phicon = AddNode.phiCon(this,this instanceof EQ);
         if( phicon!=null ) return phicon;
 

--- a/chapter22/src/main/java/com/seaofnodes/simple/node/BoolNode.java
+++ b/chapter22/src/main/java/com/seaofnodes/simple/node/BoolNode.java
@@ -71,9 +71,9 @@ abstract public class BoolNode extends Node {
                 return new NotNode(in(1));
         }
 
-        // Do we have ((x * (phi cons)) * con) ?
-        // Do we have ((x * (phi cons)) * (phi cons)) ?
-        // Push constant up through the phi: x * (phi con0*con0 con1*con1...)
+        // Do we have ((phi cons) cmp con) ?
+        // Do we have ((phi cons) cmp (phi cons)) ?
+        // Push the compare up through the phi: (phi con0 cmp con, con1 cmp con...)
         Node phicon = AddNode.phiCon(this,this instanceof EQ);
         if( phicon!=null ) return phicon;
 

--- a/chapter23/src/main/java/com/seaofnodes/simple/node/BoolNode.java
+++ b/chapter23/src/main/java/com/seaofnodes/simple/node/BoolNode.java
@@ -71,9 +71,9 @@ abstract public class BoolNode extends Node {
                 return new NotNode(in(1));
         }
 
-        // Do we have ((x * (phi cons)) * con) ?
-        // Do we have ((x * (phi cons)) * (phi cons)) ?
-        // Push constant up through the phi: x * (phi con0*con0 con1*con1...)
+        // Do we have ((phi cons) cmp con) ?
+        // Do we have ((phi cons) cmp (phi cons)) ?
+        // Push the compare up through the phi: (phi con0 cmp con, con1 cmp con...)
         Node phicon = AddNode.phiCon(this,this instanceof EQ);
         if( phicon!=null ) return phicon;
 

--- a/chapter24/src/main/java/com/seaofnodes/simple/node/BoolNode.java
+++ b/chapter24/src/main/java/com/seaofnodes/simple/node/BoolNode.java
@@ -71,9 +71,9 @@ abstract public class BoolNode extends Node {
                 return new NotNode(in(1));
         }
 
-        // Do we have ((x * (phi cons)) * con) ?
-        // Do we have ((x * (phi cons)) * (phi cons)) ?
-        // Push constant up through the phi: x * (phi con0*con0 con1*con1...)
+        // Do we have ((phi cons) cmp con) ?
+        // Do we have ((phi cons) cmp (phi cons)) ?
+        // Push the compare up through the phi: (phi con0 cmp con, con1 cmp con...)
         Node phicon = AddNode.phiCon(this,this instanceof EQ);
         if( phicon!=null ) return phicon;
 

--- a/chapter25/src/main/java/com/seaofnodes/simple/node/BoolNode.java
+++ b/chapter25/src/main/java/com/seaofnodes/simple/node/BoolNode.java
@@ -102,9 +102,9 @@ abstract public class BoolNode extends Node implements ModeNode {
                 return new NotNode(in(1));
         }
 
-        // Do we have ((x * (phi cons)) * con) ?
-        // Do we have ((x * (phi cons)) * (phi cons)) ?
-        // Push constant up through the phi: x * (phi con0*con0 con1*con1...)
+        // Do we have ((phi cons) cmp con) ?
+        // Do we have ((phi cons) cmp (phi cons)) ?
+        // Push the compare up through the phi: (phi con0 cmp con, con1 cmp con...)
         Node phicon = AddNode.phiCon(this,this instanceof EQ);
         if( phicon!=null ) return phicon;
 


### PR DESCRIPTION
The three comment lines above `AddNode.phiCon(this, ...)` in BoolNode were copy-pasted from MulNode and never adapted: they use `*` as the operator and describe the rotated shape `(x * (phi cons)) * con`.

For BoolNode neither is right. The operator is a compare, and in chapters 6-9 `rotate` is hard-coded `false`, so the rotated shape is never matched; the shapes actually handled are `(phi cons) cmp con` and `(phi cons) cmp (phi cons)`.

Reword the comment accordingly, and in chapters 6-9 add a line noting why rotate is off. Chapters 10-25 pass `this instanceof EQ`, so no such claim is made there.

Comment-only change; no code is touched.