### PR TITLE
Docs: Proj is not always a data node

### DIFF
--- a/chapter04/README.md
+++ b/chapter04/README.md
@@ -39,9 +39,12 @@ Following are revised or new nodes
 |-----------|----------------|------------------------------------------------|-----------------------|----------------------------------------------------------------------------|
 | MultiNode | Abstract class | A node that has a tuple result                 |                       | A tuple                                                                    |
 | Start     | Control        | Start of function, now a MultiNode             |                       | A tuple with a ctrl token and an `arg` data node                           |
-| Proj      | Data           | Projection nodes extract values from MultiNode | A MultiNode and index | Result is the extracted value from the input MultiNode at offset index     |
+| Proj      | Data / Control | Projection nodes extract values from MultiNode | A MultiNode and index | Result is the extracted value from the input MultiNode at offset index     |
 | Bool      | Data           | Represents results of a comparison operator    | Two data nodes        | Result is a comparison, represented as integer value where 1=true, 0=false |
 | Not       | Data           | Logical not                                    | One data node         | Result converts 0 to 1 and vice versa                                      |
+
+> A `Proj` is a control node when it projects the control slot: `Proj#0` off `Start`.
+> Every other projection is a data node.  See `ProjNode.isCFG()`.
 
 Below is our list of Nodes from [Chapter 3](../chapter03/README.md):
 

--- a/chapter05/README.md
+++ b/chapter05/README.md
@@ -41,7 +41,7 @@ Here is a recap of the nodes introduced in previous chapters:
 |-----------|----------------|---------|------------------------------------------------|-------------------------------------------------------------------------------|----------------------------------------------------------------------------|
 | Multi     | Abstract class | 4       | A node that has a tuple result                 |                                                                               | A tuple                                                                    |
 | Start     | Control        | 1       | Start of function, now a MultiNode             |                                                                               | A tuple with a ctrl token and an `arg` data node                           |
-| Proj      | Data           | 4       | Projection nodes extract values from MultiNode | A MultiNode and index                                                         | Result is the extracted value from the input MultiNode at offset index     |
+| Proj      | Data / Control | 4       | Projection nodes extract values from MultiNode | A MultiNode and index                                                         | Result is the extracted value from the input MultiNode at offset index     |
 | Bool      | Data           | 4       | Represents results of a comparison operator    | Two data nodes                                                                | Result is a comparison, represented as integer value where 1=true, 0=false |
 | Not       | Data           | 4       | Logical not                                    | One data node                                                                 | Result converts 0 to 1 and vice versa                                      |
 | Return    | Control        | 1       | End of function                                | Predecessor control node and a data node for the return value of the function | Return value of the function                                               |
@@ -52,6 +52,10 @@ Here is a recap of the nodes introduced in previous chapters:
 | Div       | Data           | 2       | Divide a value by another                      | Two data nodes, the first one is divided by the second one                    | Result of the division                                                     |
 | Minus     | Data           | 2       | Negate a value                                 | One data node which value is negated                                          | Result of the negation                                                     |
 | Scope     | Symbol Table   | 3       | Represents scopes in the graph                 | Nodes that represent the current value of variables                           | None                                                                       |
+
+> A `Proj` is a control node when it projects a control slot: `Proj#0` off `Start`,
+> and both projections off an `If`.  Every other projection is a data node.
+> See `ProjNode.isCFG()`.
 
 ## New Nodes
 


### PR DESCRIPTION
The node recap tables in chapters 4 and 5 classify `Proj` as "Data", but `ProjNode.isCFG()` has returned true for control projections since chapter 4:

  ch4:  return _idx==0;
  ch5+: return _idx==0 || ctrl() instanceof IfNode;

So `Proj#0` off `Start` is a control node, and from chapter 5 both projections off an `If` are too -- which is exactly why the dominator walk in `IfNode.compute()` can step through them.

Change the Type column to "Data / Control" and add a note under each table pointing at `isCFG()`.  Table alignment is unchanged: "Data / Control" is the same width as "Abstract class".

Docs-only change.